### PR TITLE
chore: release v1.7.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,9 +289,7 @@ bun run serve --full
 - `bun run bundle` builds the app into `dist/`
 - `bun run preview` serves `dist/` and rebuilds it when frontend files change
 - `bun run serve` starts the Tachyon app server only
-- `bun run serve --full` starts the app server and the frontend preview together
-
-By default, `serve --full` uses `PORT` for the app server and `PREVIEW_PORT` for the preview server. `PREVIEW_PORT` defaults to `3000`.
+- `bun run serve --full` serves the frontend bundle and backend API routes from the same port
 
 ### Template Syntax
 
@@ -409,7 +407,7 @@ If you are building a full-stack Tachyon app and want the app server plus the fr
 tach.serve --full
 ```
 
-That runs the normal Tachyon dev server and a background frontend preview process together.
+That runs the normal Tachyon dev server while also serving the bundled frontend from `dist/` on the same port. Browser-style `Accept: text/html` requests receive the frontend, while API-style requests still hit the route handlers.
 If you only need the static frontend preview workflow, `tach.preview --watch` is the simpler option.
 
 ### Static Hosting

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delma/tachyon",
-  "version": "1.7.0",
+  "version": "1.7.1",
     "description": "A polyglot, file-system-routed full-stack framework for Bun",
     "author": "Chidelma",
     "license": "MIT",

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -6,7 +6,9 @@ import Yon from "../compiler/template-compiler.js"
 import "../server/console-logger.js"
 import { watch } from "fs"
 import { access } from "fs/promises"
+import path from "node:path"
 import type { Middleware } from "../server/route-handler.js"
+import { serveStaticPreviewRequest } from "../runtime/static-preview.js"
 
 /** Debounce delay (ms) applied to file-watcher events before triggering an HMR reload */
 const HMR_DEBOUNCE_MS = 1000
@@ -15,7 +17,8 @@ const fullModeEnabled = process.argv.includes('--full')
 
 const start = Date.now()
 let bundleWatcher: Bun.Subprocess | null = null
-let previewWatcher: Bun.Subprocess | null = null
+const distPath = path.join(process.cwd(), 'dist')
+const bundleCliPath = `${import.meta.dir}/bundle.ts`
 
 async function pathExists(path: string): Promise<boolean> {
     try { await access(path); return true } catch { return false }
@@ -46,39 +49,35 @@ async function configureRoutes(isReload = false) {
     await Router.validateRoutes()
     Tach.createServerRoutes()
     Pool.prewarmAllHandlers()
-    await Yon.createStaticRoutes()
+    if (!fullModeEnabled) {
+        await Yon.createStaticRoutes()
+    }
+}
+
+if (fullModeEnabled) {
+    const { runBuild } = await import('./bundle.ts')
+    await runBuild()
+    Router.resetStaticState()
 }
 
 await configureRoutes()
 
-if (bundleWatchEnabled) {
-    bundleWatcher = Bun.spawn(
-        ['bun', `${import.meta.dir}/bundle.ts`, '--watch'],
-        {
-            cwd: process.cwd(),
-            stdout: 'inherit',
-            stderr: 'inherit'
-        }
-    )
+if (bundleWatchEnabled || fullModeEnabled) {
+    bundleWatcher = Bun.spawn(['bun', bundleCliPath, '--watch'], {
+        cwd: process.cwd(),
+        stdout: 'inherit',
+        stderr: 'inherit'
+    })
 }
 
 if (fullModeEnabled) {
-    const previewPort = process.env.PREVIEW_PORT || '3000'
-    const previewHost = process.env.PREVIEW_HOST || process.env.HOST || process.env.HOSTNAME || '127.0.0.1'
-
-    previewWatcher = Bun.spawn(
-        ['bun', `${import.meta.dir}/preview.ts`, '--watch'],
-        {
-            cwd: process.cwd(),
-            env: {
-                ...process.env,
-                PORT: previewPort,
-                HOST: previewHost,
-            },
-            stdout: 'inherit',
-            stderr: 'inherit'
-        }
-    )
+    Tach.setFrontendRequestHandler((request) => serveStaticPreviewRequest(
+        distPath,
+        request,
+        { allowRootFallback: false }
+    ))
+} else {
+    Tach.setFrontendRequestHandler(null)
 }
 
 let debounceTimer: Timer
@@ -87,6 +86,10 @@ const server = Bun.serve({
     idleTimeout: process.env.TIMEOUT ? Number(process.env.TIMEOUT) : 0,
 
     fetch(req, server) {
+        if (fullModeEnabled) {
+            return serveStaticPreviewRequest(distPath, req, { allowRootFallback: true })
+                .then((response) => response ?? new Response("Not Found", { status: 404 }))
+        }
 
         if (new URL(req.url).pathname !== "/hmr") {
             return new Response("Not Found", { status: 404 })
@@ -129,7 +132,6 @@ process.on('SIGINT', () => {
     clearTimeout(debounceTimer)
     Pool.clearWarmedProcesses()
     bundleWatcher?.kill()
-    previewWatcher?.kill()
     server.stop()
     process.exit(0)
 })
@@ -138,7 +140,6 @@ process.on('SIGTERM', () => {
     clearTimeout(debounceTimer)
     Pool.clearWarmedProcesses()
     bundleWatcher?.kill()
-    previewWatcher?.kill()
     server.stop()
     process.exit(0)
 })

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -55,7 +55,7 @@ async function configureRoutes(isReload = false) {
 }
 
 if (fullModeEnabled) {
-    const { runBuild } = await import('./bundle.ts')
+    const { runBuild } = await import('./bundle.js')
     await runBuild()
     Router.resetStaticState()
 }

--- a/src/runtime/app-scaffold.ts
+++ b/src/runtime/app-scaffold.ts
@@ -10,7 +10,6 @@ dist
 .DS_Store
 `,
     '.env.example': `PORT=8000
-PREVIEW_PORT=3000
 HOST=127.0.0.1
 HOSTNAME=127.0.0.1
 DEV=true
@@ -41,7 +40,7 @@ bun run serve
 bun run serve --full
 \`\`\`
 
-The bundled output is written to \`dist/\`.
+The bundled output is written to \`dist/\`. \`bun run serve --full\` serves the frontend and backend on the same port.
 `,
     'amplify.yml': `version: 1
 frontend:

--- a/src/runtime/static-preview.ts
+++ b/src/runtime/static-preview.ts
@@ -15,7 +15,12 @@ function shouldTreatAsAsset(pathname: string) {
     return basename.includes('.')
 }
 
-export async function resolvePreviewFile(distPath: string, pathname: string) {
+export async function resolvePreviewFile(
+    distPath: string,
+    pathname: string,
+    options: { allowRootFallback?: boolean } = {}
+) {
+    const allowRootFallback = options.allowRootFallback ?? true
     const normalized = pathname === '/' ? '/' : pathname.replace(/\/+$/, '') || '/'
 
     const directFile = path.join(distPath, normalized === '/' ? 'index.html' : normalized.slice(1))
@@ -25,11 +30,33 @@ export async function resolvePreviewFile(distPath: string, pathname: string) {
         const nestedIndex = path.join(distPath, normalized === '/' ? 'index.html' : normalized.slice(1), 'index.html')
         if (await pathExists(nestedIndex)) return nestedIndex
 
-        const rootIndex = path.join(distPath, 'index.html')
-        if (await pathExists(rootIndex)) return rootIndex
+        if (allowRootFallback) {
+            const rootIndex = path.join(distPath, 'index.html')
+            if (await pathExists(rootIndex)) return rootIndex
+        }
     }
 
     return null
+}
+
+export async function serveStaticPreviewRequest(
+    distPath: string,
+    req: Request,
+    options: { allowRootFallback?: boolean } = {}
+) {
+    if (req.method !== 'GET' && req.method !== 'HEAD') return null
+
+    const url = new URL(req.url)
+    const filePath = await resolvePreviewFile(distPath, url.pathname, options)
+
+    if (!filePath) return null
+
+    const file = Bun.file(filePath)
+    const body = await file.bytes()
+
+    return new Response(body, {
+        headers: file.type ? { 'Content-Type': file.type } : undefined
+    })
 }
 
 export async function createStaticPreviewServer(
@@ -40,16 +67,8 @@ export async function createStaticPreviewServer(
         port: options.port ?? Number(process.env.PORT || 3000),
         hostname: options.hostname ?? process.env.HOST ?? '127.0.0.1',
         async fetch(req) {
-            const url = new URL(req.url)
-            const filePath = await resolvePreviewFile(distPath, url.pathname)
-
-            if (!filePath) return new Response('Not Found', { status: 404 })
-
-            const file = Bun.file(filePath)
-            const body = await file.bytes()
-            return new Response(body, {
-                headers: file.type ? { 'Content-Type': file.type } : undefined
-            })
+            return await serveStaticPreviewRequest(distPath, req)
+                ?? new Response('Not Found', { status: 404 })
         }
     })
 

--- a/src/server/process-executor.ts
+++ b/src/server/process-executor.ts
@@ -8,6 +8,9 @@ import './console-logger.js'
 export default class Tach {
 
     private static readonly STREAM_MIME_TYPE = "text/event-stream"
+    private static frontendRequestHandler:
+        | ((request: BunRequest) => Promise<Response | null>)
+        | null = null
 
     /**
      * Shared decoder instance — safe to reuse since we call decode() without
@@ -130,6 +133,12 @@ export default class Tach {
         return timingSafeEqual(a, b)
     }
 
+    static setFrontendRequestHandler(
+        handler: ((request: BunRequest) => Promise<Response | null>) | null
+    ) {
+        Tach.frontendRequestHandler = handler
+    }
+
     private static async serveRequest(
         handler:  string,
         stdin:    RequestPayload,
@@ -245,6 +254,9 @@ export default class Tach {
 
                 try {
                     if (request!.headers.get('accept')?.includes('text/html')) {
+                        const frontendResponse = await Tach.frontendRequestHandler?.(request!)
+                        if (frontendResponse) return frontendResponse
+
                         return new Response(
                             await Bun.file(`${import.meta.dir}/../runtime/shells/development.html`).text(),
                             { status: 200, headers: { 'Content-Type': 'text/html' } }

--- a/tests/integration/preview-watch.test.ts
+++ b/tests/integration/preview-watch.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from 'bun:test'
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import net from 'node:net'
 import path from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -44,9 +45,31 @@ async function waitFor(check: () => Promise<boolean>, timeoutMs = 15000, interva
     throw new Error(`Condition not met within ${timeoutMs}ms`)
 }
 
+async function getFreePort() {
+    return await new Promise<number>((resolve, reject) => {
+        const server = net.createServer()
+
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', () => {
+            const address = server.address()
+            if (!address || typeof address === 'string') {
+                server.close()
+                reject(new Error('Failed to resolve an ephemeral port'))
+                return
+            }
+
+            const { port } = address
+            server.close((error) => {
+                if (error) reject(error)
+                else resolve(port)
+            })
+        })
+    })
+}
+
 test('tach.preview --watch serves initial bundle and rebuilds on HTML route changes', { timeout: 20000 }, async () => {
     const root = await createExampleApp()
-    const port = 32000 + Math.floor(Math.random() * 2000)
+    const port = await getFreePort()
     const preview = Bun.spawn(
         ['bun', path.join(import.meta.dir, '../../src/cli/preview.ts'), '--watch'],
         {

--- a/tests/integration/serve-full.test.ts
+++ b/tests/integration/serve-full.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, expect, test } from 'bun:test'
 import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import net from 'node:net'
 import path from 'node:path'
 import { tmpdir } from 'node:os'
 
@@ -42,52 +43,101 @@ async function waitFor(check: () => Promise<boolean>, timeoutMs = 15000, interva
     const start = Date.now()
 
     while (Date.now() - start < timeoutMs) {
-        if (await check()) return
+        if (await check()) return true
         await Bun.sleep(intervalMs)
     }
 
-    throw new Error(`Condition not met within ${timeoutMs}ms`)
+    return false
 }
 
-test('tach.serve --full starts the app server and preview server together', { timeout: 20000 }, async () => {
+async function getFreePort() {
+    return await new Promise<number>((resolve, reject) => {
+        const server = net.createServer()
+
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', () => {
+            const address = server.address()
+            if (!address || typeof address === 'string') {
+                server.close()
+                reject(new Error('Failed to resolve an ephemeral port'))
+                return
+            }
+
+            const { port } = address
+            server.close((error) => {
+                if (error) reject(error)
+                else resolve(port)
+            })
+        })
+    })
+}
+
+test('tach.serve --full serves frontend and backend responses from the same port', { timeout: 40000 }, async () => {
     const root = await createExampleApp()
-    const apiPort = 34000 + Math.floor(Math.random() * 1000)
-    const previewPort = apiPort + 1000
+    const port = await getFreePort()
+    const env = {
+        ...process.env,
+        PORT: String(port),
+        HOST: '127.0.0.1',
+        DEV: 'true',
+    } as Record<string, string>
+
+    delete env.BASIC_AUTH
+    delete env.VALIDATE
+
+    let lastSnapshot = 'no attempts yet'
 
     const proc = Bun.spawn(
         ['bun', path.join(import.meta.dir, '../../src/cli/serve.ts'), '--full'],
         {
             cwd: root,
-            env: {
-                ...process.env,
-                PORT: String(apiPort),
-                PREVIEW_PORT: String(previewPort),
-                HOST: '127.0.0.1',
-                PREVIEW_HOST: '127.0.0.1',
-                DEV: 'true',
-            },
-            stdout: 'ignore',
-            stderr: 'ignore'
+            env,
+            stdout: 'pipe',
+            stderr: 'pipe'
         }
     )
 
     processes.push(proc)
 
-    await waitFor(async () => {
+    const ok = await waitFor(async () => {
         try {
-            const [apiRes, previewRes] = await Promise.all([
-                fetch(`http://127.0.0.1:${apiPort}/routes.json`),
-                fetch(`http://127.0.0.1:${previewPort}/`)
+            const [frontendRes, apiRes] = await Promise.all([
+                fetch(`http://127.0.0.1:${port}/`, {
+                    headers: { accept: 'text/html' }
+                }),
+                fetch(`http://127.0.0.1:${port}/`, {
+                    headers: { accept: 'application/json' }
+                })
             ])
 
-            return apiRes.ok
-                && (await apiRes.text()).includes('"/"')
-                && previewRes.ok
-                && (await previewRes.text()).includes('Fixture Home')
+            const htmlOk = frontendRes.ok
+                && (await frontendRes.text()).includes('Fixture Home')
+            const apiOk = apiRes.ok
+                && (await apiRes.text()).includes('"fixture":"api"')
+
+            lastSnapshot = JSON.stringify({
+                htmlStatus: frontendRes.status,
+                apiStatus: apiRes.status,
+                htmlOk,
+                apiOk,
+            })
+
+            return htmlOk && apiOk
         } catch {
+            lastSnapshot = 'request connection failed'
             return false
         }
-    })
+    }, 30000)
+
+    if (!ok) {
+        proc.kill()
+        await proc.exited.catch(() => {})
+        const stdout = await new Response(proc.stdout).text()
+        const stderr = await new Response(proc.stderr).text()
+        throw new Error(
+            `serve --full did not become ready. last=${lastSnapshot}\nSTDOUT:\n${stdout}\nSTDERR:\n${stderr}`
+        )
+    }
 
     expect(proc.exitCode).toBeNull()
 })


### PR DESCRIPTION
## Summary
- make `tach.serve --full` serve frontend and backend from the same port
- build the frontend bundle before full-mode server startup
- update docs, scaffold output, and integration coverage for the unified full-mode workflow

## Verification
- bun test
- bun run typecheck (hangs locally in this environment; CI will validate on the release branch)
