### PR TITLE
chore: release v1.8.1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,16 @@ PORT=8000
 TIMEOUT=70
 LOG_LEVEL=info
 LOG_FORMAT=pretty
+# Maximum request body bytes buffered before returning HTTP 413 (default: 1048576)
+MAX_BODY_BYTES=1048576
 # Maximum ms a handler process may run before it is killed (default: 30000)
 HANDLER_TIMEOUT_MS=30000
 DEV=
 VALIDATE=
 HOSTNAME=127.0.0.1
+# Require this token for /hmr when serving on a non-loopback host
+HMR_TOKEN=
+HMR_MAX_CLIENTS=20
 ALLOW_HEADERS=*
 # Restrict to explicit origins in production — never use * with credentials enabled
 ALLOW_ORIGINS=https://yourdomain.com
@@ -19,3 +24,6 @@ ALLOW_METHODS=GET,POST,PUT,DELETE,PATCH,OPTIONS
 BASIC_AUTH=
 # Override default CSP if your app loads scripts/styles from external origins
 CONTENT_SECURITY_POLICY=default-src 'self'
+# Opt into HSTS only when serving HTTPS directly or behind a trusted HTTPS proxy
+ENABLE_HSTS=false
+HSTS_VALUE=max-age=31536000; includeSubDomains

--- a/README.md
+++ b/README.md
@@ -151,9 +151,7 @@ Every handler receives the full request context on `stdin` as a JSON object:
     "requestId": "3f5b52f8-9c2e-4f8d-8bd3-6fd2b10c28d9",
     "ipAddress": "127.0.0.1",
     "bearer": {
-      "header":   { "alg": "HS256", "typ": "JWT" },
-      "payload":  { "sub": "42", "exp": 1999999999 },
-      "signature": "...",
+      "token": "...",
       "verified": false
     }
   }
@@ -162,7 +160,7 @@ Every handler receives the full request context on `stdin` as a JSON object:
 
 Tachyon reuses an incoming `X-Request-Id` header when present, generates one when it is missing, returns it on every response, and includes it in request logs.
 
-> **Note:** `context.bearer` is decoded but the signature is **not** verified. `verified` is always `false`. Do not trust claims in `bearer.payload` without out-of-band verification (e.g. via middleware that calls a trusted auth service). Tokens with an expired `exp` claim are rejected before reaching your handler. Use the [`jose`](https://github.com/panva/jose) library for full JWT verification.
+> **Note:** `context.bearer` exposes only the raw bearer token and `verified: false`. Tachyon may decode the payload internally to reject expired JWTs, but unverified claims are not exposed to handlers. Use middleware plus a verifier such as [`jose`](https://github.com/panva/jose) when handlers need authenticated identity.
 
 ### Route Handler Examples
 
@@ -304,7 +302,8 @@ bun run serve --full
 
 | Syntax | Description |
 |--------|-------------|
-| `{expr}` | Interpolate expression |
+| `{expr}` | Interpolate and HTML-escape expression |
+| `{!expr}` | Render trusted raw HTML without escaping |
 | `@event="handler()"` | Event binding |
 | `:prop="value"` | Bind attribute to expression |
 | `:value="variable"` | Two-way input binding |
@@ -477,17 +476,21 @@ Tachyon applies the following protections by default:
 
 | Area | Protection |
 |------|-----------|
-| **Response headers** | `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Strict-Transport-Security`, `Content-Security-Policy`, `Referrer-Policy` on every response |
+| **Response headers** | `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Content-Security-Policy`, `Referrer-Policy` on every response; `Strict-Transport-Security` is opt-in with `ENABLE_HSTS=true` |
 | **Basic Auth** | Credential comparison uses `timingSafeEqual` to prevent timing oracle attacks |
-| **JWT** | Tokens with an expired `exp` claim are rejected; signature is decoded but not verified (see note above) |
+| **JWT** | Raw bearer tokens are exposed with `verified: false`; expired JWTs are rejected when their `exp` claim can be decoded |
+| **Request body limits** | Request bodies exceeding `MAX_BODY_BYTES` return HTTP 413 before handler execution |
+| **Template escaping** | Text interpolation and dynamic attributes are escaped by default; raw HTML requires `{!expr}` |
 | **Process timeout** | Handler processes that exceed `HANDLER_TIMEOUT_MS` are killed automatically |
 | **Parameter limits** | Query and path parameters exceeding `MAX_PARAM_LENGTH` characters return HTTP 400 |
-| **Error responses** | Unhandled server errors return a generic message; internal details are logged server-side only |
+| **Error responses** | Unhandled server errors and handler `stderr` failures return generic messages; internal details are logged server-side with the request id |
+| **HMR** | Development HMR defaults to `127.0.0.1`, limits clients with `HMR_MAX_CLIENTS`, and requires `HMR_TOKEN` when exposed beyond loopback |
 | **CORS** | Wildcard `ALLOW_ORIGINS=*` combined with `ALLOW_CREDENTIALS=true` is not recommended — set explicit origins in production |
 
 For production deployments:
 - Set `BASIC_AUTH` to a strong credential — never use a default value
 - Set `ALLOW_ORIGINS` to your application's domain instead of `*`
+- Set `ENABLE_HSTS=true` only when serving HTTPS directly or behind a trusted HTTPS proxy
 - Consider adding a reverse proxy (nginx, Caddy) to enforce HTTPS and add rate limiting
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delma/tachyon",
-  "version": "1.8.0",
+  "version": "1.8.1",
     "description": "A polyglot, file-system-routed full-stack framework for Bun",
     "author": "Chidelma",
     "license": "MIT",

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -4,7 +4,7 @@ import Pool from "../server/process-pool.js"
 import Router from "../server/route-handler.js"
 import Yon from "../compiler/template-compiler.js"
 import logger from "../server/logger.js"
-import { watch } from "fs"
+import { watch, type FSWatcher } from "fs"
 import { access } from "fs/promises"
 import path from "node:path"
 import type { Middleware } from "../server/route-handler.js"
@@ -20,6 +20,10 @@ let bundleWatcher: Bun.Subprocess | null = null
 const distPath = path.join(process.cwd(), 'dist')
 const bundleCliPath = `${import.meta.dir}/bundle.ts`
 const serveLogger = logger.child({ scope: 'cli:serve' })
+const hmrClients = new Set<ReadableStreamDefaultController<string>>()
+const hmrMaxClients = Number(process.env.HMR_MAX_CLIENTS) || 20
+const hmrWatchers: FSWatcher[] = []
+let hmrWatchersStarted = false
 
 async function pathExists(path: string): Promise<boolean> {
     try { await access(path); return true } catch { return false }
@@ -83,6 +87,49 @@ if (fullModeEnabled) {
 
 let debounceTimer: Timer
 
+function isLoopbackHost(hostname: string | null | undefined): boolean {
+    return hostname === '127.0.0.1' || hostname === 'localhost' || hostname === '::1'
+}
+
+function isAuthorizedHmrRequest(req: Request, hostname: string | null | undefined): boolean {
+    if (isLoopbackHost(hostname)) return true
+
+    const token = process.env.HMR_TOKEN || process.env.DEV_TOKEN
+    if (!token) return false
+
+    const url = new URL(req.url)
+    const provided = req.headers.get('X-Tachyon-Dev-Token') || url.searchParams.get('token')
+
+    return provided === token
+}
+
+async function startHmrWatchers(server: ReturnType<typeof Bun.serve>) {
+    if (hmrWatchersStarted) return
+    hmrWatchersStarted = true
+
+    const onFileChange = () => {
+        clearTimeout(debounceTimer)
+        debounceTimer = setTimeout(async () => {
+            try {
+                serveLogger.info('HMR reload started')
+                await configureRoutes(true)
+                server.reload({ routes: Router.reqRoutes })
+                for (const client of hmrClients) client.enqueue("\n\n")
+            } catch (err) {
+                serveLogger.error('HMR reload failed', { err })
+            }
+        }, HMR_DEBOUNCE_MS)
+    }
+
+    if (await pathExists(Router.routesPath)) {
+        hmrWatchers.push(watch(Router.routesPath, { recursive: true }, onFileChange))
+    }
+
+    if (await pathExists(Router.componentsPath)) {
+        hmrWatchers.push(watch(Router.componentsPath, { recursive: true }, onFileChange))
+    }
+}
+
 const server = Bun.serve({
     idleTimeout: process.env.TIMEOUT ? Number(process.env.TIMEOUT) : 0,
 
@@ -96,34 +143,40 @@ const server = Bun.serve({
             return new Response("Not Found", { status: 404 })
         }
 
+        if (!isAuthorizedHmrRequest(req, server.hostname)) {
+            return new Response("Forbidden", { status: 403 })
+        }
+
+        if (hmrClients.size >= hmrMaxClients) {
+            return new Response("Too Many HMR Clients", { status: 429 })
+        }
+
         server.timeout(req, 0)
+
+        let hmrController: ReadableStreamDefaultController<string> | null = null
 
         return new Response(new ReadableStream({
             async start(controller) {
-
-                const onFileChange = () => {
-                    clearTimeout(debounceTimer)
-                    debounceTimer = setTimeout(async () => {
-                        try {
-                            serveLogger.info('HMR reload started')
-                            await configureRoutes(true)
-                            server.reload({ routes: Router.reqRoutes })
-                            controller.enqueue("\n\n")
-                        } catch (err) {
-                            serveLogger.error('HMR reload failed', { err })
-                        }
-                    }, HMR_DEBOUNCE_MS)
-                }
-
-                if (await pathExists(Router.routesPath))     watch(Router.routesPath,     { recursive: true }, onFileChange)
-                if (await pathExists(Router.componentsPath)) watch(Router.componentsPath, { recursive: true }, onFileChange)
+                hmrController = controller
+                hmrClients.add(controller)
+                controller.enqueue(": connected\n\n")
+                await startHmrWatchers(server)
+            },
+            cancel() {
+                if (hmrController) hmrClients.delete(hmrController)
+            },
+        }), {
+            headers: {
+                "Content-Type": "text/event-stream",
+                "Cache-Control": "no-cache",
+                "Connection": "keep-alive",
             }
-        }), { headers: { "Content-Type": "text/event-stream" } })
+        })
     },
 
     routes:      Router.reqRoutes,
     port:        process.env.PORT     || 8080,
-    hostname:    process.env.HOST || process.env.HOSTNAME || '0.0.0.0',
+    hostname:    process.env.HOST || process.env.HOSTNAME || '127.0.0.1',
     development: !!process.env.DEV,
 })
 
@@ -136,6 +189,7 @@ serveLogger.info('Server started', {
 
 process.on('SIGINT', () => {
     clearTimeout(debounceTimer)
+    for (const watcher of hmrWatchers) watcher.close()
     Pool.clearWarmedProcesses()
     bundleWatcher?.kill()
     server.stop()
@@ -145,6 +199,7 @@ process.on('SIGINT', () => {
 
 process.on('SIGTERM', () => {
     clearTimeout(debounceTimer)
+    for (const watcher of hmrWatchers) watcher.close()
     Pool.clearWarmedProcesses()
     bundleWatcher?.kill()
     server.stop()

--- a/src/compiler/render-template.js
+++ b/src/compiler/render-template.js
@@ -56,6 +56,19 @@ export default async function(props) {
             return ''
         }
 
+        const ty_escapeHtml = (value) => {
+            if(value === null || value === undefined) return ''
+            return String(value)
+                .replaceAll('&', '&amp;')
+                .replaceAll('<', '&lt;')
+                .replaceAll('>', '&gt;')
+                .replaceAll('"', '&quot;')
+                .replaceAll("'", '&#39;')
+        }
+
+        const ty_escapeText = ty_escapeHtml
+        const ty_escapeAttr = ty_escapeHtml
+
         let elements = '';
 
         let render;

--- a/src/compiler/template-compiler.ts
+++ b/src/compiler/template-compiler.ts
@@ -523,8 +523,17 @@ export default class Yon {
                 return `${name}="${value}"`;
             };
 
-            const interpolate = (text: string) =>
-                text.replace(/\{([^{}]+)\}/g, '${$1}').replace(/\{\{([^{}]+)\}\}/g, '{${$1}}');
+            const interpolate = (text: string) => {
+                const rawExpressions: string[] = [];
+
+                return text
+                    .replace(/\{!\s*([^{}]+?)\s*\}/g, (_match, expr) => {
+                        rawExpressions.push(expr);
+                        return `__TY_RAW_${rawExpressions.length - 1}__`;
+                    })
+                    .replace(/\{\s*([^{}!][^{}]*?)\s*\}/g, (_match, expr) => `\${ty_escapeText(${expr})}`)
+                    .replace(/__TY_RAW_(\d+)__/g, (_match, index) => `\${${rawExpressions[Number(index)]}}`);
+            };
 
             const rewriter = new HTMLRewriter()
                 .on('script', {
@@ -656,8 +665,8 @@ export default class Yon {
             .replaceAll(/`<logic :else-if="(.*?)">`|`<\/logic>`/g, (_, expr) => expr ? `else if(${expr}) {` : '}')
             .replaceAll(/`<logic else="">`|`<\/logic>`/g, (_, expr) => expr ? `else {` : '}');
 
-        // Bind dynamic attributes :attr="expr" → attr="${expr}"
-        code = code.replaceAll(/:(\w[\w-]*)="([^"]*)"/g, '$1="${$2}"');
+        // Bind dynamic attributes :attr="expr" → attr="${escaped expr}"
+        code = code.replaceAll(/:(\w[\w-]*)="([^"]*)"/g, '$1="${ty_escapeAttr($2)}"');
 
         // Transform component invocations
         code = code.replaceAll(/`<([A-Za-z0-9-]+)_\s*([^/>]*)\/>`/g, (_, component, attrStr) => {

--- a/src/runtime/app-scaffold.ts
+++ b/src/runtime/app-scaffold.ts
@@ -1,7 +1,7 @@
 import { mkdir, readdir, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-const version = '1.8.0'
+const version = '1.8.1'
 
 const files = {
     '.gitignore': `node_modules
@@ -15,6 +15,10 @@ HOSTNAME=127.0.0.1
 DEV=true
 LOG_LEVEL=info
 LOG_FORMAT=pretty
+MAX_BODY_BYTES=1048576
+HMR_TOKEN=
+HMR_MAX_CLIENTS=20
+ENABLE_HSTS=false
 `,
     'package.json': JSON.stringify({
         name: 'tachyon-app',

--- a/src/server/process-executor.ts
+++ b/src/server/process-executor.ts
@@ -59,6 +59,14 @@ export default class Tach {
         return value ? Buffer.byteLength(value) : 0
     }
 
+    private static handlerErrorBody(stderr?: string): string {
+        if (process.env.DEV === 'true' && process.env.DEV_ERROR_DETAILS === 'true' && stderr) {
+            return JSON.stringify({ detail: stderr })
+        }
+
+        return JSON.stringify({ detail: 'Internal server error' })
+    }
+
     private static async logHandlerResourceUsage(
         proc: ReturnType<typeof Pool.acquireHandler>,
         context: RequestContext,
@@ -137,7 +145,7 @@ export default class Tach {
         )
 
         if (out.length > 0) return { status: 200, body: out }
-        if (err.length > 0) return { status: 500, body: err }
+        if (err.length > 0) return { status: 500, body: Tach.handlerErrorBody(err) }
         return { status: 200 }
     }
 
@@ -202,9 +210,9 @@ export default class Tach {
         )
 
         if (errRemainder.length > 0) {
-            yield { status: 500, body: errRemainder }
+            yield { status: 500, body: Tach.handlerErrorBody(errRemainder) }
         } else if (stderrLines.length > 0) {
-            yield { status: 500, body: JSON.stringify({ detail: stderrLines.join(' ') }) }
+            yield { status: 500, body: Tach.handlerErrorBody(stderrLines.join(' ')) }
         }
     }
 
@@ -308,40 +316,34 @@ export default class Tach {
     }
 
     /**
-     * Decodes a Bearer JWT from an Authorization header.
-     * WARNING: The signature is NOT verified. Route handlers must not trust claims
-     * without out-of-band verification (e.g. via a middleware that calls a trusted
-     * auth service). Rejects tokens whose `exp` claim is in the past.
+     * Extracts a Bearer token without exposing decoded claims to handlers.
+     * The token is decoded only internally to reject expired JWTs when possible.
      * @param authorization - The raw `Authorization` header value
      */
-    private static decodeJWT(authorization: string | undefined) {
+    private static getBearerContext(authorization: string | undefined): RequestContext['bearer'] {
         if (!authorization) return undefined
 
         const [authType, token] = authorization.split(' ')
 
-        if (authType.toLowerCase() !== "bearer") return undefined
+        if (authType?.toLowerCase() !== "bearer" || !token) return undefined
 
-        const [header, payload, signature] = token.split('.')
+        const [, payload] = token.split('.')
 
         try {
-            const decodedPayload: Record<string, unknown> = JSON.parse(atob(payload))
+            if (payload) {
+                const decodedPayload: Record<string, unknown> = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'))
 
-            // Reject expired tokens even without full signature verification
-            if (typeof decodedPayload.exp === 'number' && decodedPayload.exp < Math.floor(Date.now() / 1000)) {
-                Tach.processLogger.warn('Rejected expired JWT', { exp: decodedPayload.exp })
-                return undefined
-            }
-
-            return {
-                header:     JSON.parse(atob(header)),
-                payload:    decodedPayload,
-                signature,
-                verified:   false as const, // Signature NOT verified — do not trust claims without separate verification
+                // Reject expired tokens even without exposing unverified claims.
+                if (typeof decodedPayload.exp === 'number' && decodedPayload.exp < Math.floor(Date.now() / 1000)) {
+                    Tach.processLogger.warn('Rejected expired JWT', { exp: decodedPayload.exp })
+                    return undefined
+                }
             }
         } catch {
-            Tach.processLogger.warn('Failed to decode JWT payload')
-            return undefined
+            Tach.processLogger.warn('Failed to decode JWT payload; exposing raw bearer token only')
         }
+
+        return { token, verified: false as const }
     }
 
     /**
@@ -399,7 +401,7 @@ export default class Tach {
                         if (!res) {
                             const { handler, stdin, config } = await Router.processRequest(request!, route)
 
-                            context.bearer = Tach.decodeJWT(stdin.headers?.authorization)
+                            context.bearer = Tach.getBearerContext(stdin.headers?.authorization)
 
                             res = await Tach.serveRequest(handler, stdin, context, config)
 

--- a/src/server/route-handler.ts
+++ b/src/server/route-handler.ts
@@ -5,10 +5,8 @@ export interface RequestContext {
     requestId: string
     ipAddress: string
     bearer?: {
-        header: Record<string, unknown>
-        payload: Record<string, unknown>
-        signature: string
-        /** Always false — signature is decoded but NOT cryptographically verified */
+        token: string
+        /** Always false unless application middleware replaces it with verified auth context */
         verified: false
     }
 }
@@ -68,20 +66,30 @@ export default class Router {
         ? process.env.ALLOW_METHODS.split(',')
         : ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD']
 
-    static headers = {
-        "Access-Control-Allow-Headers":    process.env.ALLOW_HEADERS     || "",
-        "Access-Control-Allow-Origin":     process.env.ALLOW_ORIGINS     || "",
-        "Access-Control-Allow-Credential": process.env.ALLOW_CREDENTIALS || "false",
-        "Access-Control-Expose-Headers":   process.env.ALLOW_EXPOSE_HEADERS || "",
-        "Access-Control-Max-Age":          process.env.ALLOW_MAX_AGE     || "",
-        "Access-Control-Allow-Methods":    process.env.ALLOW_METHODS     || "",
-        // Security headers
-        "X-Frame-Options":                 "DENY",
-        "X-Content-Type-Options":          "nosniff",
-        "Strict-Transport-Security":       "max-age=31536000; includeSubDomains",
-        "Content-Security-Policy":         process.env.CONTENT_SECURITY_POLICY || "default-src 'self'",
-        "Referrer-Policy":                 "strict-origin-when-cross-origin",
+    static get headers(): Record<string, string> {
+        const headers: Record<string, string> = {
+            "Access-Control-Allow-Headers":      process.env.ALLOW_HEADERS     || "",
+            "Access-Control-Allow-Origin":       process.env.ALLOW_ORIGINS     || "",
+            "Access-Control-Allow-Credentials":  process.env.ALLOW_CREDENTIALS || "false",
+            "Access-Control-Expose-Headers":     process.env.ALLOW_EXPOSE_HEADERS || "",
+            "Access-Control-Max-Age":            process.env.ALLOW_MAX_AGE     || "",
+            "Access-Control-Allow-Methods":      process.env.ALLOW_METHODS     || "",
+            // Security headers
+            "X-Frame-Options":                   "DENY",
+            "X-Content-Type-Options":            "nosniff",
+            "Content-Security-Policy":           process.env.CONTENT_SECURITY_POLICY || "default-src 'self'",
+            "Referrer-Policy":                   "strict-origin-when-cross-origin",
+        }
+
+        if (process.env.ENABLE_HSTS === 'true') {
+            headers["Strict-Transport-Security"] = process.env.HSTS_VALUE || "max-age=31536000; includeSubDomains"
+        }
+
+        return headers
     }
+
+    /** Maximum bytes buffered from an inbound request body before returning 413. */
+    static readonly MAX_BODY_BYTES = Number(process.env.MAX_BODY_BYTES) || 1_048_576
 
     /**
      * Validates a route file path, registers slugs, and records allowed methods.
@@ -153,11 +161,12 @@ export default class Router {
 
         stdin.headers = request.headers.toJSON()
 
-        const blob = await request.blob()
+        const bodyBytes = await Router.readBodyBytes(request)
 
-        if (blob.size > 0) {
+        if (bodyBytes.byteLength > 0) {
             const contentType = request.headers.get('content-type') ?? ''
-            stdin.body = contentType.includes('json') ? await blob.json() : await blob.text()
+            const bodyText = new TextDecoder().decode(bodyBytes)
+            stdin.body = contentType.includes('json') ? JSON.parse(bodyText) : bodyText
         }
 
         const searchParams = new URL(request.url).searchParams
@@ -167,6 +176,43 @@ export default class Router {
         }
 
         return { handler: `${Router.routesPath}${route}/${request.method}`, stdin, config: requestConfig }
+    }
+
+    private static async readBodyBytes(request: Request): Promise<Uint8Array> {
+        const contentLength = request.headers.get('content-length')
+
+        if (contentLength && Number(contentLength) > Router.MAX_BODY_BYTES) {
+            throw Response.json({ error: 'Payload too large' }, { status: 413, headers: Router.headers })
+        }
+
+        if (!request.body) return new Uint8Array()
+
+        const reader = request.body.getReader()
+        const chunks: Uint8Array[] = []
+        let total = 0
+
+        while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            if (!value) continue
+
+            total += value.byteLength
+            if (total > Router.MAX_BODY_BYTES) {
+                await reader.cancel()
+                throw Response.json({ error: 'Payload too large' }, { status: 413, headers: Router.headers })
+            }
+
+            chunks.push(value)
+        }
+
+        const body = new Uint8Array(total)
+        let offset = 0
+        for (const chunk of chunks) {
+            body.set(chunk, offset)
+            offset += chunk.byteLength
+        }
+
+        return body
     }
 
     /** Maximum allowed length for any single route or query parameter value. */

--- a/tests/integration/api-routes.test.ts
+++ b/tests/integration/api-routes.test.ts
@@ -40,6 +40,8 @@ beforeAll(async () => {
             PORT: TEST_PORT,
             HOSTNAME: '127.0.0.1',
             BASIC_AUTH: TEST_BASIC_AUTH,
+            ENABLE_HSTS: 'false',
+            MAX_BODY_BYTES: '64',
         },
         stdout: 'inherit',
         stderr: 'inherit'
@@ -237,6 +239,17 @@ describe('Request body parsing', () => {
         const res = await authFetch('/api', { method: 'POST' })
         expect(res.status).toEqual(200)
     })
+
+    test('body exceeding MAX_BODY_BYTES returns 413 before handler execution', async () => {
+        const res = await authFetch('/api', {
+            method: 'POST',
+            headers: { 'Content-Type': 'text/plain' },
+            body: 'x'.repeat(65),
+        })
+        expect(res.status).toEqual(413)
+        const body = await res.json()
+        expect(body.error).toBe('Payload too large')
+    })
 })
 
 // ===========================================================================
@@ -299,16 +312,16 @@ describe('404 Not Found', () => {
 // CORS Headers
 // ===========================================================================
 describe('CORS headers', () => {
-    test('response includes Access-Control-Allow-Credential header', async () => {
+    test('response includes Access-Control-Allow-Credentials header', async () => {
         const res = await authFetch('/api')
         // ALLOW_CREDENTIALS defaults to "false" when not set
-        expect(res.headers.get('access-control-allow-credential')).toBe('false')
+        expect(res.headers.get('access-control-allow-credentials')).toBe('false')
     })
 
-    test('401 response includes Access-Control-Allow-Credential header', async () => {
+    test('401 response includes Access-Control-Allow-Credentials header', async () => {
         const res = await fetch(`${BASE_URL}/api`)
         expect(res.status).toEqual(401)
-        expect(res.headers.get('access-control-allow-credential')).toBe('false')
+        expect(res.headers.get('access-control-allow-credentials')).toBe('false')
     })
 })
 
@@ -764,12 +777,9 @@ describe('Security headers', () => {
         expect(res.headers.get('x-content-type-options')).toBe('nosniff')
     })
 
-    test('response includes Strict-Transport-Security header', async () => {
+    test('plain local HTTP responses do not include Strict-Transport-Security by default', async () => {
         const res = await authFetch('/api')
-        const hsts = res.headers.get('strict-transport-security')
-        expect(hsts).not.toBeNull()
-        expect(hsts).toContain('max-age=')
-        expect(hsts).toContain('includeSubDomains')
+        expect(res.headers.get('strict-transport-security')).toBeNull()
     })
 
     test('response includes Content-Security-Policy header', async () => {

--- a/tests/integration/bundle-static-export.test.ts
+++ b/tests/integration/bundle-static-export.test.ts
@@ -95,6 +95,32 @@ function status() {
     return root
 }
 
+async function createEscapingFixture() {
+    const root = await mkdtemp(path.join(tmpdir(), 'tachyon-escaping-'))
+    tempDirs.push(root)
+
+    await mkdir(path.join(root, 'routes'), { recursive: true })
+
+    await writeFile(path.join(root, 'package.json'), JSON.stringify({
+        name: 'tachyon-escaping-fixture',
+        private: true
+    }, null, 2))
+
+    await writeFile(
+        path.join(root, 'routes', 'HTML'),
+        `<script>
+let message = '<img src=x onerror=alert(1)>';
+let title = '" onfocus="alert(1)';
+let trusted = '<strong>Trusted raw HTML</strong>';
+</script>
+<p>{message}</p>
+<div :title="title">Hover me</div>
+<section>{!trusted}</section>`
+    )
+
+    return root
+}
+
 async function decode(stream: ReadableStream<Uint8Array> | null) {
     if (!stream) return ''
     return await new Response(stream).text()
@@ -119,7 +145,7 @@ test('tach.bundle prerenders HTML routes into static documents', { timeout: 2000
         proc.exited
     ])
 
-    expect(exitCode).toBe(0)
+    if (exitCode !== 0) throw new Error(stderr)
     expect(stderr).toBe('')
     expect(stdout).toContain('Bundle completed')
 
@@ -152,7 +178,7 @@ test('tach.bundle classifies component, web component, native, and unknown tags 
         proc.exited
     ])
 
-    expect(exitCode).toBe(0)
+    if (exitCode !== 0) throw new Error(stderr)
     expect(stdout).toContain('Bundle completed')
     expect(stderr).toContain('Unknown element tag')
     expect(stderr).toContain('tag=mystery')
@@ -181,7 +207,7 @@ test('loop-scoped event handlers can access loop variables when rerendered', { t
         proc.exited
     ])
 
-    expect(exitCode).toBe(0)
+    if (exitCode !== 0) throw new Error(stderr)
     expect(stderr).toBe('')
 
     const pageModulePath = path.join(cwd, 'dist', 'pages', 'HTML.js')
@@ -197,4 +223,34 @@ test('loop-scoped event handlers can access loop variables when rerendered', { t
     const updated = await render()
 
     expect(updated).toContain('done')
+})
+
+test('template interpolation and dynamic attributes are escaped by default', { timeout: 20000 }, async () => {
+    const cwd = await createEscapingFixture()
+
+    const proc = Bun.spawn(['bun', bundleEntrypoint], {
+        cwd,
+        stdout: 'pipe',
+        stderr: 'pipe'
+    })
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+        decode(proc.stdout),
+        decode(proc.stderr),
+        proc.exited
+    ])
+
+    if (exitCode !== 0) throw new Error(stderr)
+    expect(stderr).toBe('')
+
+    const pageModulePath = path.join(cwd, 'dist', 'pages', 'HTML.js')
+    const pageModule = await import(`${pathToFileURL(pageModulePath).href}?escaping=${Date.now()}`)
+    const render = await pageModule.default()
+    const html = await render()
+
+    expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;')
+    expect(html).not.toContain('<img src=x onerror=alert(1)>')
+    expect(html).toContain('title="&quot; onfocus=&quot;alert(1)"')
+    expect(html).not.toContain('title="" onfocus="alert(1)"')
+    expect(html).toContain('<strong>Trusted raw HTML</strong>')
 })


### PR DESCRIPTION
## Summary
- release @delma/tachyon v1.8.1
- apply security audit fixes for body limits, template escaping, handler error leakage, HMR hardening, bearer context safety, CORS header correctness, and HSTS opt-in
- remove SECURITY_AUDIT.txt from the release payload per request

## Verification
- bun install --frozen-lockfile
- (cd examples && bun install --frozen-lockfile)
- bun run typecheck
- bun test
- bun audit --json
- GitHub Actions CI passed on release/1.8.1
- GitHub Actions Publish passed and published v1.8.1