### PR TITLE
chore: rename Chidelma GitHub URLs to d31ma org

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     ],
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/Chidelma/Tachyon.git"
+        "url": "git+https://github.com/d31ma/Tachyon.git"
     },
     "homepage": "https://tachyon.del.ma",
     "bugs": {
-        "url": "https://github.com/Chidelma/Tachyon/issues"
+        "url": "https://github.com/d31ma/Tachyon/issues"
     },
     "devDependencies": {
         "@happy-dom/global-registrator": "^20.8.9",


### PR DESCRIPTION
## Summary
- Update hard-coded `github.com/Chidelma/*` URLs to `github.com/d31ma/*` following the repo transfer to the d31ma GitHub organization

## Notes
- `author` field in `package.json` and LICENSE copyright were intentionally not touched — those identify the human maintainer, not the org
- GitHub preserves HTTP redirects from the old URLs, so nothing was broken; this is cosmetic cleanup

## Test plan
- [ ] CI green
- [ ] Manual review of link changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)