### PR TITLE
chore(ci): use org-level BLACKBOX_SSH_KEY/BLACKBOX_REPOSITORY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,23 +65,23 @@ jobs:
 
       - name: Require private blackbox credentials
         env:
-          BLACKBOX_REPOSITORY: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY }}
-          BLACKBOX_SSH_KEY: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY }}
+          BLACKBOX_REPOSITORY: ${{ vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY }}
+          BLACKBOX_SSH_KEY: ${{ secrets.BLACKBOX_SSH_KEY }}
         run: |
           if [ -z "$BLACKBOX_REPOSITORY" ]; then
-            echo "::error::Missing TACHYON_BLACKBOX_REPOSITORY variable or secret"
+            echo "::error::Missing BLACKBOX_REPOSITORY variable or secret"
             exit 1
           fi
           if [ -z "$BLACKBOX_SSH_KEY" ]; then
-            echo "::error::Missing TACHYON_BLACKBOX_SSH_KEY secret"
+            echo "::error::Missing BLACKBOX_SSH_KEY secret"
             exit 1
           fi
 
       - name: Checkout private blackbox suite
         uses: actions/checkout@v6
         with:
-          repository: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY }}
-          ssh-key: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY }}
+          repository: ${{ vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY }}
+          ssh-key: ${{ secrets.BLACKBOX_SSH_KEY }}
           ref: ${{ vars.TACHYON_BLACKBOX_REF || 'main' }}
           path: .blackbox-tests
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,23 +60,23 @@ jobs:
 
       - name: Require private blackbox credentials
         env:
-          BLACKBOX_REPOSITORY: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY }}
-          BLACKBOX_SSH_KEY: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY }}
+          BLACKBOX_REPOSITORY: ${{ vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY }}
+          BLACKBOX_SSH_KEY: ${{ secrets.BLACKBOX_SSH_KEY }}
         run: |
           if [ -z "$BLACKBOX_REPOSITORY" ]; then
-            echo "::error::Missing TACHYON_BLACKBOX_REPOSITORY variable or secret"
+            echo "::error::Missing BLACKBOX_REPOSITORY variable or secret"
             exit 1
           fi
           if [ -z "$BLACKBOX_SSH_KEY" ]; then
-            echo "::error::Missing TACHYON_BLACKBOX_SSH_KEY secret"
+            echo "::error::Missing BLACKBOX_SSH_KEY secret"
             exit 1
           fi
 
       - name: Checkout private blackbox suite
         uses: actions/checkout@v6
         with:
-          repository: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY }}
-          ssh-key: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY }}
+          repository: ${{ vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY }}
+          ssh-key: ${{ secrets.BLACKBOX_SSH_KEY }}
           ref: ${{ vars.TACHYON_BLACKBOX_REF || 'main' }}
           path: .blackbox-tests
 


### PR DESCRIPTION
## Summary
- Rename repo-scoped blackbox secret/var references to the new org-level `BLACKBOX_SSH_KEY` + `BLACKBOX_REPOSITORY` shared across d31ma/{HERMES,Tachyon,Fylo}.
- One shared deploy key, one var, one rotation touch-point going forward.

## Test plan
- [ ] `Image blackbox tests` / `Package blackbox tests` / `NightJar blackbox tests` succeeds with the org-level credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)