### PR TITLE
Release v1.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,13 +314,13 @@ The global format keeps the same runtime behavior, but compiled modules are clas
 |--------|-------------|
 | `{expr}` | Interpolate and HTML-escape expression |
 | `{!expr}` | Render trusted raw HTML without escaping |
-| `@event="handler()"` | Event binding |
+| `@event="handler()"` | Event binding; handlers receive `$event` |
 | `:prop="value"` | Bind attribute to expression |
 | `:value="variable"` | Two-way input binding |
 | `<loop :for="...">` | Loop block |
 | `<logic :if="...">` | Conditional block |
-| `<myComp_ prop=val />` | Custom component (trailing `_`) |
-| `<myComp_ lazy />` | Lazy-loaded component (renders when visible) |
+| `<my-comp prop=val />` | Custom component from `components/my-comp.html` |
+| `<my-comp lazy />` | Lazy-loaded component (renders when visible) |
 
 ### Custom Components
 
@@ -336,7 +336,34 @@ The global format keeps the same runtime behavior, but compiled modules are clas
 Use in a page:
 
 ```html
-<counter_ />
+<counter />
+```
+
+Components can emit custom events to their parent wrapper with `emit(name, detail)`.
+Parent handlers receive the browser `CustomEvent` as `$event`, so payloads are
+available at `$event.detail`.
+
+```html
+<!-- components/item-picker.html -->
+<script>
+  let label = 'Default'
+
+  function choose() {
+    emit('selected', { label })
+  }
+</script>
+
+<button @click="choose()">Choose {label}</button>
+```
+
+```html
+<!-- routes/HTML -->
+<script>
+  let selected = 'none'
+</script>
+
+<item-picker label="Tachyon" @selected="selected = $event.detail.label" />
+<p>Selected: {selected}</p>
 ```
 
 ### Lazy Loading
@@ -345,10 +372,10 @@ Add the `lazy` attribute to defer a component's loading until it scrolls into vi
 
 ```html
 <!-- Eager (default) — loaded immediately -->
-<counter_ />
+<counter />
 
 <!-- Lazy — loaded when visible in the viewport -->
-<counter_ lazy />
+<counter lazy />
 ```
 
 Lazy components are fully interactive once loaded — event delegation and state management work identically to eager components.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delma/tachyon",
-  "version": "1.9.0",
+  "version": "1.10.0",
     "description": "A polyglot, file-system-routed full-stack framework for Bun",
     "author": "Chidelma",
     "license": "MIT",

--- a/src/compiler/render-template.js
+++ b/src/compiler/render-template.js
@@ -2,6 +2,8 @@ export default async function(props) {
 
     // imports
 
+    let emit = () => false
+
     // script
 
     if(props) {
@@ -19,6 +21,23 @@ export default async function(props) {
     return async function(elemId, event, compId) {
 
         const counters = { id: {}, ev: {}, bind: {} }
+        const ty_componentRootId = compId
+            ? (String(compId).startsWith('ty-') ? String(compId) : 'ty-' + compId + '-0')
+            : null
+
+        emit = (name, detail) => {
+            const eventName = String(name || '').replace(/^@/, '')
+            if(!eventName || !ty_componentRootId || typeof document === 'undefined') return false
+
+            const target = document.getElementById(ty_componentRootId)
+            if(!target || typeof CustomEvent === 'undefined') return false
+
+            return target.dispatchEvent(new CustomEvent(eventName, {
+                detail,
+                bubbles: true,
+                composed: true
+            }))
+        }
 
         const ty_generateId = (hash, source) => {
 

--- a/src/compiler/template-compiler.ts
+++ b/src/compiler/template-compiler.ts
@@ -573,7 +573,7 @@ export default class Yon {
 
             const formatAttr = (name: string, value: string, hash: string): string => {
                 if (name.startsWith('@'))
-                    return `${name}="\${await ty_invokeEvent('${hash}', (__event__) => { ${value} })}"`;
+                    return `${name}="\${await ty_invokeEvent('${hash}', ($event) => { const __event__ = $event; ${value} })}"`;
                 if (name === ':value')
                     return `value="\${ty_assignValue('${hash}', '${value}')}"`;
                 return `${name}="${value}"`;
@@ -702,7 +702,7 @@ export default class Yon {
                 // Control flow and component tags are raw JS, not concatenated
                 if (el.element.includes('<loop') || el.element.includes('</loop') ||
                     el.element.includes('<logic') || el.element.includes('</logic') ||
-                    /<([A-Za-z0-9-]+)_\s*([^/>]*)\/>/.test(el.element)) {
+                    /<([A-Za-z0-9-]+)_\s*([\s\S]*?)\/>/.test(el.element)) {
                     body.push(el.element);
                 } else {
                     body.push(`elements+=${el.element}`);
@@ -729,7 +729,7 @@ export default class Yon {
         code = code.replaceAll(/:(\w[\w-]*)="([^"]*)"/g, '$1="${ty_escapeAttr($2)}"');
 
         // Transform component invocations
-        code = code.replaceAll(/`<([A-Za-z0-9-]+)_\s*([^/>]*)\/>`/g, (_, component, attrStr) => {
+        code = code.replaceAll(/`<([A-Za-z0-9-]+)_\s*([\s\S]*?)\/>`/g, (_, component, attrStr) => {
             const matches = attrStr.matchAll(/([a-zA-Z0-9-@]+)="([^"]*)"/g);
             const props: string[] = [];
             const events: string[] = [];

--- a/src/runtime/app-scaffold.ts
+++ b/src/runtime/app-scaffold.ts
@@ -1,7 +1,7 @@
 import { mkdir, readdir, stat, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 
-const version = '1.9.0'
+const version = '1.10.0'
 
 const files = {
     '.gitignore': `node_modules

--- a/src/runtime/spa-renderer.ts
+++ b/src/runtime/spa-renderer.ts
@@ -7,7 +7,7 @@ import {
   resolveHandler,
 } from './dom-helpers.js';
 
-type RenderFn = (elementId?: string | null, eventDetail?: unknown) => Promise<string>;
+type RenderFn = (elementId?: string | null, eventDetail?: unknown, componentRootId?: string | null) => Promise<string>;
 type RenderFactory = (props?: unknown) => Promise<RenderFn>;
 type YonGlobal = {
   version: string;
@@ -72,6 +72,7 @@ const layouts: Record<string, string> = {};
 const slugs: Record<string, string> = {};
 let params: (string | number | boolean | null | undefined)[] = [];
 const yon = getYonGlobal();
+const delegatedEvents = new Set<string>();
 
 async function loadManifests() {
   const [routeData, layoutData] = await Promise.all([
@@ -96,27 +97,50 @@ Promise.all([
 });
 
 // ── Event Delegation ───────────────────────────────────────────────────────────
-// Single delegated listener at the document level instead of per-element binding.
-// Handles both `@event` attribute actions and `:value` two-way binding.
-document.addEventListener('click', (ev: MouseEvent) => {
-  // SPA link interception
-  const anchor = (ev.target as Element)?.closest('a[href]') as HTMLAnchorElement | null;
-  if (anchor) {
-    const url = new URL(anchor.href, location.origin);
-    if (url.origin === location.origin) {
-      ev.preventDefault();
-      navigate(url.pathname);
-      return;
+// Single delegated listener per event name at the document level.
+function ensureDelegatedEvent(eventName: string) {
+  if (!eventName || delegatedEvents.has(eventName)) return;
+  delegatedEvents.add(eventName);
+  document.addEventListener(eventName, (ev: Event) => handleDelegatedEvent(eventName, ev));
+}
+
+function handleDelegatedEvent(eventName: string, ev: Event) {
+  const eventTarget = ev.target instanceof Element ? ev.target : null;
+
+  if (eventName === 'click') {
+    // SPA link interception
+    const anchor = eventTarget?.closest('a[href]') as HTMLAnchorElement | null;
+    if (anchor) {
+      const url = new URL(anchor.href, location.origin);
+      if (url.origin === location.origin) {
+        ev.preventDefault();
+        navigate(url.pathname);
+        return;
+      }
     }
   }
 
-  // Delegated @click
-  const target = findEventTarget(ev.target as Element, 'click');
+  const target = findEventTarget(eventTarget, eventName);
   if (target) {
-    ev.preventDefault();
-    dispatchAction(target);
+    if (eventName === 'click' || eventName === 'submit') ev.preventDefault();
+    dispatchAction(target, ev);
   }
-});
+}
+
+function registerDeclarativeEvents(root: ParentNode = document.body) {
+  const elements = root instanceof Element
+    ? [root, ...Array.from(root.querySelectorAll('*'))]
+    : Array.from(root.querySelectorAll('*'));
+
+  for (const el of elements) {
+    for (const attr of Array.from(el.attributes)) {
+      if (attr.name.startsWith('@')) ensureDelegatedEvent(attr.name.slice(1));
+    }
+  }
+}
+
+// Keep same-origin navigation active even on pages without an explicit @click.
+ensureDelegatedEvent('click');
 
 // Value-change events (input, change, sl-input, sl-change)
 for (const eventName of ['input', 'change', 'sl-input', 'sl-change'] as const) {
@@ -130,8 +154,8 @@ for (const eventName of ['input', 'change', 'sl-input', 'sl-change'] as const) {
 
 window.addEventListener('popstate', () => navigate(location.pathname));
 
-function dispatchAction(el: Element) {
-  rerender(el.id);
+function dispatchAction(el: Element, eventDetail?: unknown) {
+  rerender(el.id, eventDetail);
 }
 
 function findLazyAncestor(elementId: string): HTMLElement | null {
@@ -150,8 +174,8 @@ async function rerender(triggerId: string, eventDetail?: unknown) {
   const lazyContainer = findLazyAncestor(triggerId);
   if (lazyContainer) {
     const render = lazyRenders.get(lazyContainer.id) as RenderFn;
-    await render(triggerId, eventDetail);
-    const html = await render();
+    await render(triggerId, eventDetail, lazyContainer.id);
+    const html = await render(null, undefined, lazyContainer.id);
     morphChildren(lazyContainer, parseFragment(html), {
       preserveElement: (el) => lazyRenders.has(el.id)
     });
@@ -290,14 +314,11 @@ async function loadLazyComponent(el: HTMLElement) {
     const factory = await yon.load(modulePath);
     const render = await factory(props);
     lazyRenders.set(el.id, render);
-    el.innerHTML = await render();
+    el.innerHTML = await render(null, undefined, el.id);
     el.removeAttribute('data-lazy-component');
     el.removeAttribute('data-lazy-path');
     el.removeAttribute('data-lazy-props');
-
-    // Wire up event delegation for lazy-loaded content
-    const eventEls = el.querySelectorAll('[\\@click]');
-    // Events are already handled by delegation — no extra wiring needed
+    postPatch();
   } catch (e) {
     console.error(`[tachyon] Failed to load lazy component "${path}":`, e);
   }
@@ -314,6 +335,7 @@ function observeLazyComponents() {
 
 function postPatch() {
   cleanBooleanAttrs();
+  registerDeclarativeEvents();
   observeLazyComponents();
   if (focusTarget) {
     const el = document.getElementById(focusTarget);

--- a/tests/integration/bundle-static-export.test.ts
+++ b/tests/integration/bundle-static-export.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { tmpdir } from 'node:os'
 import { pathToFileURL } from 'node:url'
+import { Window } from 'happy-dom'
 
 const tempDirs: string[] = []
 const bundleEntrypoint = path.join(process.cwd(), 'src/cli/bundle.ts')
@@ -169,6 +170,44 @@ async function requestMfa() {
 </script>
 <button @click="requestMfa()">Continue</button>
 <p>{status}</p>`
+    )
+
+    return root
+}
+
+async function createComponentEmitFixture() {
+    const root = await mkdtemp(path.join(tmpdir(), 'tachyon-component-emit-'))
+    tempDirs.push(root)
+
+    await mkdir(path.join(root, 'routes'), { recursive: true })
+    await mkdir(path.join(root, 'components'), { recursive: true })
+
+    await writeFile(path.join(root, 'package.json'), JSON.stringify({
+        name: 'tachyon-component-emit-fixture',
+        private: true
+    }, null, 2))
+
+    await writeFile(
+        path.join(root, 'components', 'child-picker.html'),
+        `<script>
+let label = 'fallback';
+function choose() {
+    emit('selected', { label, source: 'child-picker' });
+}
+</script>
+<button @click="choose()">Choose {label}</button>`
+    )
+
+    await writeFile(
+        path.join(root, 'routes', 'HTML'),
+        `<script>
+let selected = 'none';
+function receive(event) {
+    selected = event.detail.label + ':' + event.detail.source;
+}
+</script>
+<child-picker label="alpha" @selected="receive($event)" />
+<p>Selected {selected}</p>`
     )
 
     return root
@@ -373,4 +412,72 @@ test('async event handlers are awaited before Yon rerenders', { timeout: 20000 }
 
     expect(updated).toContain('>phone-input</p>')
     expect(updated).not.toContain('>loading</p>')
+})
+
+test('components can emit custom events handled by their parent wrapper', { timeout: 20000 }, async () => {
+    const cwd = await createComponentEmitFixture()
+
+    const proc = Bun.spawn(['bun', bundleEntrypoint], {
+        cwd,
+        stdout: 'pipe',
+        stderr: 'pipe'
+    })
+
+    const [_stdout, stderr, exitCode] = await Promise.all([
+        decode(proc.stdout),
+        decode(proc.stderr),
+        proc.exited
+    ])
+
+    if (exitCode !== 0) throw new Error(stderr)
+    expect(stderr).toBe('')
+
+    const pageModulePath = path.join(cwd, 'dist', 'pages', 'HTML.js')
+    const pageModule = await import(`${pathToFileURL(pageModulePath).href}?component-emit=${Date.now()}`)
+    const render = await pageModule.default()
+    const initial = await render()
+
+    const windowInstance = new Window()
+    const previousGlobals = {
+        window: globalThis.window,
+        document: globalThis.document,
+        CustomEvent: globalThis.CustomEvent,
+    }
+
+    try {
+        Object.assign(windowInstance, {
+            SyntaxError,
+        })
+
+        Object.assign(globalThis, {
+            window: windowInstance,
+            document: windowInstance.document,
+            CustomEvent: windowInstance.CustomEvent,
+        })
+
+        document.body.innerHTML = initial
+
+        const wrapperId = initial.match(/<div id="([^"]+)" @selected/)?.[1]
+        const wrapper = wrapperId ? document.getElementById(wrapperId) as HTMLDivElement | null : null
+        const button = document.querySelector('button') as HTMLButtonElement | null
+
+        expect(wrapper?.id).toBeTruthy()
+        expect(button?.id).toBeTruthy()
+        expect(initial).toContain('Selected none')
+
+        const received = new Promise<unknown>((resolve) => {
+            wrapper!.addEventListener('selected', async (event) => {
+                await render(wrapper!.id, event)
+                resolve((event as CustomEvent).detail)
+            })
+        })
+
+        await render(button!.id, new windowInstance.MouseEvent('click'))
+
+        expect(await received).toEqual({ label: 'alpha', source: 'child-picker' })
+        expect(await render()).toContain('Selected alpha:child-picker')
+    } finally {
+        await windowInstance.happyDOM.close()
+        Object.assign(globalThis, previousGlobals)
+    }
 })


### PR DESCRIPTION
## Summary
- add first-class Yon component event emits with bubbling CustomEvent payloads
- generalize Yon delegated event handling beyond @click so parent wrappers can listen to custom @events
- document component emits and bump package/scaffold version to 1.10.0

## Verification
- bun run typecheck
- bun test
- git diff --check
- bun pm pack --filename /tmp/tachyon-release-1.10.0.tgz --quiet
- TACHYON_PACKAGE_TARBALL=/tmp/tachyon-release-1.10.0.tgz bun run blackbox:tachyon

## Release Notes
- New Yon API: components can call emit(name, detail), and parent component wrappers can handle @name with $event.detail.