### PR TITLE
feat: release v1.11.0

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -90,6 +90,6 @@ jobs:
 
             Use inline comments for specific actionable findings. Use a single top-level PR comment for the summary, including when there are no findings. In the summary, briefly state what project areas you inspected beyond the diff.
           claude_args: |
-            --max-turns 20
+            --max-turns 30
             --model claude-opus-4-7
             --allowedTools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -91,5 +91,5 @@ jobs:
             Use inline comments for specific actionable findings. Use a single top-level PR comment for the summary, including when there are no findings. In the summary, briefly state what project areas you inspected beyond the diff.
           claude_args: |
             --max-turns 30
-            --model claude-opus-4-7
+            --model claude-sonnet-4-6
             --allowedTools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -90,6 +90,6 @@ jobs:
 
             Use inline comments for specific actionable findings. Use a single top-level PR comment for the summary, including when there are no findings. In the summary, briefly state what project areas you inspected beyond the diff.
           claude_args: |
-            --max-turns 6
+            --max-turns 20
             --model claude-opus-4-7
             --allowedTools "Read,Grep,Glob,mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/README.md
+++ b/README.md
@@ -459,6 +459,10 @@ Yon.provide('toast', (msg) => showToast(msg))
 
 `inject` returns `undefined` (or the provided fallback) during prerender so components remain SSG-safe.
 
+> **Context scope:** `provide` / `inject` share a single app-level context map that lives for the whole page session — values persist across SPA navigations and are not scoped per route. Use `Yon.provide` in `main.js` for app-wide services. Calling `provide` from a component script is valid but the value will remain available globally for the rest of the session.
+
+> **Load order:** `Yon.provide` is available once `spa-renderer.ts` initialises, which happens before any page or component factory runs. Call `Yon.provide(...)` at the top level of `main.js` (not inside an event handler or timeout) to ensure services are registered before the first component mounts.
+
 #### `persist`
 
 Preserve component state across SPA navigations using `sessionStorage`. The factory reads the stored value on every mount, so state survives navigating away and back.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Tachyon is a **polyglot, file-system-routed full-stack framework for [Bun](https
 - **Auth** — built-in Basic Auth (timing-safe) and JWT decoding with expiry enforcement
 - **Security headers** — X-Frame-Options, X-Content-Type-Options, HSTS, CSP, and Referrer-Policy sent on every response
 - **Streaming** — SSE responses via `Accept: text/event-stream`
+- **Script primitives** — `onMount`, `rerender`, `inject`/`provide`, `persist`, `isBrowser`/`isServer` available in every component script
+- **Navigation events** — `tachyon:navigate` dispatched on `window` after every SPA navigation
 
 ## Installation
 
@@ -379,6 +381,119 @@ Add the `lazy` attribute to defer a component's loading until it scrolls into vi
 ```
 
 Lazy components are fully interactive once loaded — event delegation and state management work identically to eager components.
+
+### Script Primitives
+
+Every component `<script>` block has access to the following built-in primitives:
+
+| Primitive | Description |
+|-----------|-------------|
+| `isBrowser` | `true` in the browser, `false` during prerender |
+| `isServer` | Inverse of `isBrowser` |
+| `onMount(fn)` | Run `fn` once after the component's first browser render; no-op during prerender |
+| `rerender()` | Trigger a mid-handler repaint without waiting for the handler to fully resolve |
+| `inject(key, fallback?)` | Retrieve a value registered with `provide` or `Yon.provide` |
+| `provide(key, value)` | Register a value in the app-level context |
+| `persist(key, init)` | Returns `[currentValue, save]` backed by `sessionStorage` |
+| `emit(name, detail)` | Dispatch a custom event from a component to its parent wrapper |
+
+#### `onMount`
+
+Use `onMount` to run browser-only setup code without sprinkling `typeof window !== 'undefined'` guards everywhere. The callback fires after the component's first DOM patch.
+
+```html
+<script>
+  onMount(() => {
+    document.title = 'Dashboard'
+    window.addEventListener('tachyon:navigate', syncActiveLink)
+  })
+</script>
+```
+
+#### `rerender`
+
+Calling `rerender()` mid-handler triggers an immediate repaint of the current component state, letting you show loading indicators before an async operation completes:
+
+```html
+<script>
+  let loading = false
+  let result = null
+
+  async function fetchData() {
+    loading = true
+    rerender()  // show spinner now
+
+    const res = await fetch('/api/data')
+    result = await res.json()
+    loading = false
+  }
+</script>
+
+<logic :if="loading"><p>Loading…</p></logic>
+<logic :if="!loading && result"><p>{result.name}</p></logic>
+<button @click="fetchData()">Fetch</button>
+```
+
+#### `provide` / `inject`
+
+Share services or values across components without polluting `window`. Call `Yon.provide` (or the `provide` primitive) before components mount, then `inject` in any component that needs it.
+
+```js
+// main.js
+Yon.provide('apiFetch', (path, opts) => fetch(path, { ...opts, credentials: 'include' }))
+Yon.provide('toast', (msg) => showToast(msg))
+```
+
+```html
+<!-- any component -->
+<script>
+  const apiFetch = inject('apiFetch')
+  const toast = inject('toast')
+
+  async function send() {
+    const res = await apiFetch('/api/send', { method: 'POST' })
+    if (res.ok) toast('Sent!')
+  }
+</script>
+```
+
+`inject` returns `undefined` (or the provided fallback) during prerender so components remain SSG-safe.
+
+#### `persist`
+
+Preserve component state across SPA navigations using `sessionStorage`. The factory reads the stored value on every mount, so state survives navigating away and back.
+
+```html
+<script>
+  let [step, saveStep] = persist('onboarding-step', 1)
+  let [formData, saveFormData] = persist('onboarding-form', {})
+
+  function next() {
+    step++
+    saveStep(step)
+  }
+
+  function updateField(key, value) {
+    formData = { ...formData, [key]: value }
+    saveFormData(formData)
+  }
+</script>
+```
+
+`save` serialises the value as JSON. Returns `[initialValue, noop]` during prerender.
+
+### Navigation Events
+
+Tachyon dispatches a `tachyon:navigate` `CustomEvent` on `window` after every SPA navigation settles. The event detail contains the new `pathname`.
+
+```js
+window.addEventListener('tachyon:navigate', (e) => {
+  console.log('Navigated to', e.detail.pathname)
+  syncActiveNavLink(e.detail.pathname)
+})
+```
+
+This is especially useful for layout components that need to react to route changes without being re-rendered.
 
 ### NPM Modules in Front-end Code
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@delma/tachyon",
-  "version": "1.10.0",
+  "version": "1.11.0",
     "description": "A polyglot, file-system-routed full-stack framework for Bun",
     "author": "Chidelma",
     "license": "MIT",

--- a/src/compiler/render-template.js
+++ b/src/compiler/render-template.js
@@ -4,7 +4,7 @@ export default async function(props) {
 
     let emit = () => false
 
-    const isBrowser = typeof window !== 'undefined'
+    const isBrowser = typeof window !== 'undefined' && !globalThis.__ty_prerender__
     const isServer = !isBrowser
 
     const onMount = (fn) => {
@@ -28,9 +28,14 @@ export default async function(props) {
 
     const persist = (key, initialValue) => {
         if (!isBrowser) return [initialValue, () => {}]
-        const stored = sessionStorage.getItem(key)
-        const current = stored !== null ? JSON.parse(stored) : initialValue
-        const save = (newValue) => sessionStorage.setItem(key, JSON.stringify(newValue))
+        let current = initialValue
+        try {
+            const stored = sessionStorage.getItem(key)
+            if (stored !== null) current = JSON.parse(stored)
+        } catch {}
+        const save = (newValue) => {
+            try { sessionStorage.setItem(key, JSON.stringify(newValue)) } catch {}
+        }
         return [current, save]
     }
 

--- a/src/compiler/render-template.js
+++ b/src/compiler/render-template.js
@@ -4,6 +4,36 @@ export default async function(props) {
 
     let emit = () => false
 
+    const isBrowser = typeof window !== 'undefined'
+    const isServer = !isBrowser
+
+    const onMount = (fn) => {
+        if (!isBrowser) return
+        if (!window.__ty_onMount_queue__) window.__ty_onMount_queue__ = []
+        window.__ty_onMount_queue__.push(fn)
+    }
+
+    const rerender = () => {
+        if (isBrowser) window.__ty_rerender?.()
+    }
+
+    const inject = (key, fallback = undefined) => {
+        if (!isBrowser) return fallback
+        return window.__ty_context__?.get(key) ?? fallback
+    }
+
+    const provide = (key, value) => {
+        if (isBrowser) window.__ty_context__?.set(key, value)
+    }
+
+    const persist = (key, initialValue) => {
+        if (!isBrowser) return [initialValue, () => {}]
+        const stored = sessionStorage.getItem(key)
+        const current = stored !== null ? JSON.parse(stored) : initialValue
+        const save = (newValue) => sessionStorage.setItem(key, JSON.stringify(newValue))
+        return [current, save]
+    }
+
     // script
 
     if(props) {

--- a/src/compiler/template-compiler.ts
+++ b/src/compiler/template-compiler.ts
@@ -295,6 +295,7 @@ export default class Yon {
         Object.assign(globalThis, {
             document: documentStub,
             window: globalThis,
+            __ty_prerender__: true,
             Yon: {
                 version: '1',
                 modules,
@@ -331,6 +332,8 @@ export default class Yon {
 
                 if (previousYon === undefined) Reflect.deleteProperty(globalThis as Record<string, unknown>, 'Yon')
                 else Object.assign(globalThis, { Yon: previousYon })
+
+                Reflect.deleteProperty(globalThis as Record<string, unknown>, '__ty_prerender__')
             }
         }
     }

--- a/src/runtime/spa-renderer.ts
+++ b/src/runtime/spa-renderer.ts
@@ -23,7 +23,7 @@ declare global {
   interface Window {
     Yon?: YonGlobal;
     __ty_rerender?: () => Promise<void>;
-    __ty_onMount_queue__?: Array<() => void>;
+    __ty_onMount_queue__?: Array<() => void | Promise<void>>;
     __ty_context__?: Map<string, unknown>;
   }
 }
@@ -350,18 +350,21 @@ function postPatch() {
     focusTarget = null;
   }
 
-  if (freshNavigation) {
-    window.dispatchEvent(new CustomEvent('tachyon:navigate', { detail: { pathname: location.pathname } }));
-  }
-  freshNavigation = false;
-
   const queue = window.__ty_onMount_queue__;
   if (queue?.length) {
     window.__ty_onMount_queue__ = [];
     for (const fn of queue) {
-      try { fn(); } catch (e) { console.error('[tachyon] onMount callback error:', e); }
+      try {
+        const r = fn();
+        if (r instanceof Promise) r.catch(e => console.error('[tachyon] onMount callback error:', e));
+      } catch (e) { console.error('[tachyon] onMount callback error:', e); }
     }
   }
+
+  if (freshNavigation) {
+    window.dispatchEvent(new CustomEvent('tachyon:navigate', { detail: { pathname: location.pathname } }));
+  }
+  freshNavigation = false;
 }
 
 // ── Navigation / Routing ───────────────────────────────────────────────────────

--- a/src/runtime/spa-renderer.ts
+++ b/src/runtime/spa-renderer.ts
@@ -16,12 +16,15 @@ type YonGlobal = {
   load(path: string): Promise<RenderFactory>;
   navigate?: (pathname: string) => void;
   rerender?: (triggerId: string, eventDetail?: unknown) => Promise<void>;
+  provide?: (key: string, value: unknown) => void;
 };
 
 declare global {
   interface Window {
     Yon?: YonGlobal;
     __ty_rerender?: () => Promise<void>;
+    __ty_onMount_queue__?: Array<() => void>;
+    __ty_context__?: Map<string, unknown>;
   }
 }
 
@@ -58,6 +61,10 @@ function getYonGlobal(): YonGlobal {
   window.Yon = Object.assign(existing ?? {}, yon);
   return window.Yon;
 }
+
+// ── Context ────────────────────────────────────────────────────────────────────
+const context = new Map<string, unknown>();
+window.__ty_context__ = context;
 
 // ── State ──────────────────────────────────────────────────────────────────────
 let pageRender: RenderFn;
@@ -342,7 +349,19 @@ function postPatch() {
     if (el) try { el.focus(); } catch {}
     focusTarget = null;
   }
+
+  if (freshNavigation) {
+    window.dispatchEvent(new CustomEvent('tachyon:navigate', { detail: { pathname: location.pathname } }));
+  }
   freshNavigation = false;
+
+  const queue = window.__ty_onMount_queue__;
+  if (queue?.length) {
+    window.__ty_onMount_queue__ = [];
+    for (const fn of queue) {
+      try { fn(); } catch (e) { console.error('[tachyon] onMount callback error:', e); }
+    }
+  }
 }
 
 // ── Navigation / Routing ───────────────────────────────────────────────────────
@@ -441,6 +460,7 @@ function resolvePageHandler(pathname: string): string {
 Object.assign(yon, {
   navigate,
   rerender,
+  provide: (key: string, value: unknown) => context.set(key, value),
 });
 
 window.__ty_rerender = refreshCurrentView;

--- a/tests/runtime/render-template.test.ts
+++ b/tests/runtime/render-template.test.ts
@@ -1,0 +1,207 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test'
+import { Window } from 'happy-dom'
+import path from 'node:path'
+import os from 'node:os'
+
+const TEMPLATE_PATH = new URL('../../src/compiler/render-template.js', import.meta.url).pathname
+
+/**
+ * Builds a factory from render-template.js with test code injected into the
+ * script slot. Results are returned via globalThis.__ty_test__ to bridge
+ * the ESM module boundary.
+ */
+async function buildTestFactory(testScript: string): Promise<(props?: unknown) => Promise<unknown>> {
+    const source = await Bun.file(TEMPLATE_PATH).text()
+    const modified = source
+        .replace('// imports', '')
+        .replace('// script', testScript)
+        .replace('// inners', '')
+    const tmpPath = path.join(os.tmpdir(), `tachyon-tpl-${Bun.randomUUIDv7()}.js`)
+    await Bun.write(tmpPath, modified)
+    const { default: factory } = await import(tmpPath)
+    return factory as (props?: unknown) => Promise<unknown>
+}
+
+function testResults(): Record<string, unknown> {
+    const results: Record<string, unknown> = {}
+    ;(globalThis as Record<string, unknown>).__ty_test__ = results
+    return results
+}
+
+// ── Server-side (no window) ────────────────────────────────────────────────────
+
+describe('render-template server-side (no window)', () => {
+    test('isBrowser is false and isServer is true', async () => {
+        const r = testResults()
+        const factory = await buildTestFactory(`__ty_test__.isBrowser = isBrowser; __ty_test__.isServer = isServer`)
+        await factory()
+        expect(r.isBrowser).toBe(false)
+        expect(r.isServer).toBe(true)
+    })
+
+    test('onMount is a no-op — callback is never registered or called', async () => {
+        const r = testResults()
+        r.called = false
+        const factory = await buildTestFactory(`onMount(() => { __ty_test__.called = true })`)
+        await factory()
+        expect(r.called).toBe(false)
+    })
+
+    test('inject returns fallback when window is absent', async () => {
+        const r = testResults()
+        const factory = await buildTestFactory(`__ty_test__.value = inject('key', 'fallback')`)
+        await factory()
+        expect(r.value).toBe('fallback')
+    })
+
+    test('inject returns undefined fallback by default', async () => {
+        const r = testResults()
+        const factory = await buildTestFactory(`__ty_test__.value = inject('key')`)
+        await factory()
+        expect(r.value).toBeUndefined()
+    })
+
+    test('persist returns [initialValue, noop] without window', async () => {
+        const r = testResults()
+        const factory = await buildTestFactory(`
+            const [val, save] = persist('k', 42)
+            __ty_test__.val = val
+            __ty_test__.noopResult = save('anything')
+        `)
+        await factory()
+        expect(r.val).toBe(42)
+        expect(r.noopResult).toBeUndefined()
+    })
+
+    test('rerender is a no-op without window', async () => {
+        const factory = await buildTestFactory(`rerender()`)
+        expect(async () => await factory()).not.toThrow()
+    })
+})
+
+// ── Browser-side (with happy-dom window) ──────────────────────────────────────
+
+describe('render-template browser-side (with window)', () => {
+    let windowInstance: Window
+    let previousGlobals: Record<string, unknown>
+
+    beforeAll(() => {
+        windowInstance = new Window()
+        previousGlobals = {
+            window: (globalThis as Record<string, unknown>).window,
+            sessionStorage: (globalThis as Record<string, unknown>).sessionStorage,
+            CustomEvent: (globalThis as Record<string, unknown>).CustomEvent,
+        }
+        Object.assign(globalThis, {
+            window: windowInstance,
+            sessionStorage: windowInstance.sessionStorage,
+            CustomEvent: windowInstance.CustomEvent,
+        })
+    })
+
+    afterAll(async () => {
+        await windowInstance.happyDOM.close()
+        Object.assign(globalThis, previousGlobals)
+    })
+
+    test('isBrowser is true and isServer is false', async () => {
+        const r = testResults()
+        const factory = await buildTestFactory(`__ty_test__.isBrowser = isBrowser; __ty_test__.isServer = isServer`)
+        await factory()
+        expect(r.isBrowser).toBe(true)
+        expect(r.isServer).toBe(false)
+    })
+
+    test('onMount pushes callback to window.__ty_onMount_queue__', async () => {
+        delete (windowInstance as Record<string, unknown>).__ty_onMount_queue__
+        const r = testResults()
+        r.called = false
+        const factory = await buildTestFactory(`onMount(() => { __ty_test__.called = true })`)
+        await factory()
+        const queue = (windowInstance as Record<string, unknown>).__ty_onMount_queue__ as Array<() => void>
+        expect(Array.isArray(queue)).toBe(true)
+        expect(queue.length).toBe(1)
+        queue[0]()
+        expect(r.called).toBe(true)
+    })
+
+    test('multiple onMount calls append to the queue in order', async () => {
+        delete (windowInstance as Record<string, unknown>).__ty_onMount_queue__
+        const r = testResults()
+        r.order = []
+        const factory = await buildTestFactory(`
+            onMount(() => { __ty_test__.order.push(1) })
+            onMount(() => { __ty_test__.order.push(2) })
+        `)
+        await factory()
+        const queue = (windowInstance as Record<string, unknown>).__ty_onMount_queue__ as Array<() => void>
+        queue.forEach(fn => fn())
+        expect(r.order).toEqual([1, 2])
+    })
+
+    test('inject retrieves value from window.__ty_context__', async () => {
+        const ctx = new Map([['apiBase', 'https://api.example.com']])
+        ;(windowInstance as Record<string, unknown>).__ty_context__ = ctx
+        const r = testResults()
+        const factory = await buildTestFactory(`__ty_test__.value = inject('apiBase')`)
+        await factory()
+        expect(r.value).toBe('https://api.example.com')
+    })
+
+    test('inject returns fallback for absent key', async () => {
+        ;(windowInstance as Record<string, unknown>).__ty_context__ = new Map()
+        const r = testResults()
+        const factory = await buildTestFactory(`__ty_test__.value = inject('missing', 'default')`)
+        await factory()
+        expect(r.value).toBe('default')
+    })
+
+    test('provide sets value in window.__ty_context__', async () => {
+        const ctx = new Map()
+        ;(windowInstance as Record<string, unknown>).__ty_context__ = ctx
+        const factory = await buildTestFactory(`provide('svc', { url: '/api' })`)
+        await factory()
+        expect(ctx.get('svc')).toEqual({ url: '/api' })
+    })
+
+    test('persist restores value from sessionStorage on factory init', async () => {
+        windowInstance.sessionStorage.setItem('testRestore', JSON.stringify({ id: 7 }))
+        const r = testResults()
+        const factory = await buildTestFactory(`const [val] = persist('testRestore', null); __ty_test__.val = val`)
+        await factory()
+        expect(r.val).toEqual({ id: 7 })
+        windowInstance.sessionStorage.removeItem('testRestore')
+    })
+
+    test('persist returns initialValue when key is absent from sessionStorage', async () => {
+        windowInstance.sessionStorage.removeItem('absentKey')
+        const r = testResults()
+        const factory = await buildTestFactory(`const [val] = persist('absentKey', 'init'); __ty_test__.val = val`)
+        await factory()
+        expect(r.val).toBe('init')
+    })
+
+    test('persist save writes JSON to sessionStorage', async () => {
+        windowInstance.sessionStorage.removeItem('writeKey')
+        const factory = await buildTestFactory(`const [, save] = persist('writeKey', null); save({ persisted: true })`)
+        await factory()
+        const stored = windowInstance.sessionStorage.getItem('writeKey')
+        expect(JSON.parse(stored ?? 'null')).toEqual({ persisted: true })
+    })
+
+    test('rerender calls window.__ty_rerender', async () => {
+        const r = testResults()
+        r.called = false
+        ;(windowInstance as Record<string, unknown>).__ty_rerender = () => { r.called = true }
+        const factory = await buildTestFactory(`rerender()`)
+        await factory()
+        expect(r.called).toBe(true)
+        delete (windowInstance as Record<string, unknown>).__ty_rerender
+    })
+
+    test('rerender is safe when window.__ty_rerender is absent', async () => {
+        delete (windowInstance as Record<string, unknown>).__ty_rerender
+        const factory = await buildTestFactory(`rerender()`)
+        expect(async () => await factory()).not.toThrow()
+    })
+})

--- a/tests/runtime/render-template.test.ts
+++ b/tests/runtime/render-template.test.ts
@@ -204,4 +204,68 @@ describe('render-template browser-side (with window)', () => {
         const factory = await buildTestFactory(`rerender()`)
         expect(async () => await factory()).not.toThrow()
     })
+
+    test('persist is safe with malformed sessionStorage value', async () => {
+        windowInstance.sessionStorage.setItem('badJson', 'not-valid-json{{{')
+        const r = testResults()
+        const factory = await buildTestFactory(`const [val] = persist('badJson', 'safe'); __ty_test__.val = val`)
+        await factory()
+        expect(r.val).toBe('safe')
+        windowInstance.sessionStorage.removeItem('badJson')
+    })
+})
+
+// ── Prerender-environment (window = globalThis, no sessionStorage) ─────────────
+
+describe('render-template prerender-environment (window=globalThis, __ty_prerender__=true)', () => {
+    let previousGlobals: Record<string, unknown>
+
+    beforeAll(() => {
+        previousGlobals = {
+            window: (globalThis as Record<string, unknown>).window,
+            __ty_prerender__: (globalThis as Record<string, unknown>).__ty_prerender__,
+        }
+        Object.assign(globalThis, {
+            window: globalThis,
+            __ty_prerender__: true,
+        })
+    })
+
+    afterAll(() => {
+        Object.assign(globalThis, previousGlobals)
+        if (previousGlobals.__ty_prerender__ === undefined) {
+            Reflect.deleteProperty(globalThis as Record<string, unknown>, '__ty_prerender__')
+        }
+    })
+
+    test('isBrowser is false and isServer is true despite window being set', async () => {
+        const r = testResults()
+        const factory = await buildTestFactory(`__ty_test__.isBrowser = isBrowser; __ty_test__.isServer = isServer`)
+        await factory()
+        expect(r.isBrowser).toBe(false)
+        expect(r.isServer).toBe(true)
+    })
+
+    test('onMount does not push to any queue during prerender', async () => {
+        const r = testResults()
+        r.called = false
+        const factory = await buildTestFactory(`onMount(() => { __ty_test__.called = true })`)
+        await factory()
+        expect(r.called).toBe(false)
+        expect((globalThis as Record<string, unknown>).__ty_onMount_queue__).toBeUndefined()
+    })
+
+    test('persist returns [initialValue, noop] during prerender without crashing', async () => {
+        const r = testResults()
+        const factory = await buildTestFactory(`const [val, save] = persist('someKey', 99); __ty_test__.val = val; save(100)`)
+        await factory()
+        expect(r.val).toBe(99)
+    })
+
+    test('inject returns fallback during prerender', async () => {
+        const r = testResults()
+        const factory = await buildTestFactory(`__ty_test__.value = inject('k', 'prerender-fallback')`)
+        await factory()
+        expect(r.value).toBe('prerender-fallback')
+    })
 })

--- a/tests/runtime/render-template.test.ts
+++ b/tests/runtime/render-template.test.ts
@@ -118,7 +118,7 @@ describe('render-template browser-side (with window)', () => {
         r.called = false
         const factory = await buildTestFactory(`onMount(() => { __ty_test__.called = true })`)
         await factory()
-        const queue = (windowInstance as Record<string, unknown>).__ty_onMount_queue__ as Array<() => void>
+        const queue = (windowInstance as Record<string, unknown>).__ty_onMount_queue__ as Array<() => void | Promise<void>>
         expect(Array.isArray(queue)).toBe(true)
         expect(queue.length).toBe(1)
         queue[0]()
@@ -134,7 +134,7 @@ describe('render-template browser-side (with window)', () => {
             onMount(() => { __ty_test__.order.push(2) })
         `)
         await factory()
-        const queue = (windowInstance as Record<string, unknown>).__ty_onMount_queue__ as Array<() => void>
+        const queue = (windowInstance as Record<string, unknown>).__ty_onMount_queue__ as Array<() => void | Promise<void>>
         queue.forEach(fn => fn())
         expect(r.order).toEqual([1, 2])
     })


### PR DESCRIPTION
## Summary

- Inject `isBrowser`, `isServer`, `onMount`, `rerender`, `inject`, `provide`, and `persist` into every component script scope via `render-template.js`
- Dispatch `tachyon:navigate` `CustomEvent` on `window` after every SPA navigation settles (`postPatch`, gated on `freshNavigation`)
- Drain `window.__ty_onMount_queue__` in `postPatch` after every DOM patch (covers page navigations and lazy component loads)
- Expose `Yon.provide(key, value)` on the global Yon object for app-root service registration
- Wire `window.__ty_context__` context map in `spa-renderer.ts` at startup
- Add 17 unit tests covering all new primitives (server-side no-op paths + browser-side happy-dom paths)
- Bump version `1.10.0` → `1.11.0`
- Update README with Script Primitives and Navigation Events sections

Closes #29, #30, #31, #32, #33. Bugs #23 and #24 were already fixed in v1.9.0 and have been closed.

## Test plan

- [x] `bun test tests/runtime/ tests/server/` — 27 pass, 0 fail
- [x] `bun run typecheck` — no errors
- [ ] CI checks pass on this branch
- [ ] Claude PR review resolves clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added script primitives: lifecycle hook (onMount), context sharing (provide/inject), persistence (persist), and rerender; plus SPA navigation event (tachyon:navigate) and browser/server detection.

* **Documentation**
  * Expanded README with a Script Primitives section and navigation event details.

* **Tests**
  * Added comprehensive runtime tests covering server, browser, and prerender scenarios.

* **Chores**
  * Bumped package version to 1.11.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->