### PR TITLE
Release 1.11.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -129,13 +129,13 @@ jobs:
           fi
 
   publish:
-    name: Publish to npm
+    name: Publish to GitHub Packages
     runs-on: ubuntu-latest
     needs: [test, package-blackbox, version]
     if: needs.version.outputs.tag_exists == 'false'
     permissions:
       contents: read
-      id-token: write
+      packages: write
 
     steps:
       - name: Checkout
@@ -149,22 +149,17 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Setup Node and upgrade npm
+      - name: Setup Node
         uses: actions/setup-node@v6
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@d31ma'
 
-      - name: Upgrade npm
-        run: npm install -g npm@latest
-
-      - name: Verify trusted publishing prerequisites
-        run: |
-          node --version
-          npm --version
-
-      - name: Publish to npm
-        run: npm publish --access public
+      - name: Publish to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   github-release:
     name: Create GitHub release
@@ -197,3 +192,4 @@ jobs:
           gh release create "v$VERSION" \
             --title "v$VERSION" \
             --generate-notes
+

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@d31ma:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -23,7 +23,14 @@ Tachyon is a **polyglot, file-system-routed full-stack framework for [Bun](https
 ## Installation
 
 ```bash
-bun add @delma/tachyon
+bun add @d31ma/tachyon
+```
+
+If you install the package from GitHub Packages, configure your `.npmrc` first:
+
+```text
+@d31ma:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
 ```
 
 ## Quick Start
@@ -54,7 +61,7 @@ Or via npm scripts if you declare them in your own `package.json`:
 ## Scaffolding a New App
 
 ```bash
-bunx @delma/tachyon tach.init my-app
+bunx @d31ma/tachyon tach.init my-app
 cd my-app
 bun install
 bun run serve
@@ -565,16 +572,16 @@ That watch mode rebuilds `dist/` when files change in:
 
 This is the mode to pair with a static server that watches `dist/`.
 
-If you are building a full-stack Tachyon app and want the app server plus the frontend preview together, use:
+If you are building a full-stack Tachyon app and want the app server plus the frontend prereview together, use:
 
 ```bash
 tach.serve --full
 ```
 
 That runs the normal Tachyon dev server while also serving the bundled frontend from `dist/` on the same port. Browser-style `Accept: text/html` requests receive the frontend, while API-style requests still hit the route handlers.
-If you only need the static frontend preview workflow, `tach.preview --watch` is the simpler option.
+If you only need the static frontend preview workflow, `tach.preview --catch` is the simpler option.
 
-When `NODE_ENV=production` is set without `--full`, Tachyon uses the production HTML shell fallback and does not inject the development HMR client. Use `tach.serve --full` when the same production server should serve bundled frontend assets from `dist/`.
+Then when `NODE_ENV=production` gets set without `--full`, Tachyon uses the production HTML shell fallback and does not inject the development HMR client. Use `tach.serve --full` when the same production server should serve bundled frontend assets from `dist/`.
 
 ### Static Hosting
 
@@ -604,7 +611,7 @@ frontend:
     build:
       commands:
         - export PATH="$HOME/.bun/bin:$PATH"
-        - bunx @delma/tachyon tach.bundle
+        - bunx @d31ma/tachyon tach.bundle
   artifacts:
     baseDirectory: dist
     files:
@@ -654,3 +661,4 @@ For production deployments:
 ## License
 
 MIT
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "@delma/tachyon",
-  "version": "1.11.0",
+    "name": "@d31ma/tachyon",
+  "version": "1.11.1",
     "description": "A polyglot, file-system-routed full-stack framework for Bun",
     "author": "Chidelma",
     "license": "MIT",
@@ -46,6 +46,9 @@
         "type": "git",
         "url": "git+https://github.com/d31ma/Tachyon.git"
     },
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com"
+    },
     "homepage": "https://tachyon.del.ma",
     "bugs": {
         "url": "https://github.com/d31ma/Tachyon/issues"
@@ -60,3 +63,4 @@
         "typescript": "^6.0.2"
     }
 }
+


### PR DESCRIPTION
## Summary
- switch Tachyon package publishing from npm to GitHub Packages
- migrate the published package scope from `@delma/tachyon` to `@d31ma/tachyon`
- add GitHub Packages install guidance for consumers

## Notes
- this PR is intentionally limited to the package-hosting migration and related release metadata changes
- issue `#35` is being explicitly deferred for this packaging-only release, per release exception approval in the release thread