### PR TITLE
[codex] Harden TACHYON CI/CD baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,19 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test (Bun ${{ matrix.bun-version }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     strategy:
       matrix:
@@ -42,11 +51,36 @@ jobs:
           HOSTNAME: 127.0.0.1
           BASIC_AUTH: admin:pass
 
+  blackbox-config:
+    name: Detect blackbox configuration
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.detect.outputs.enabled }}
+    env:
+      BLACKBOX_REPOSITORY: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
+
+    steps:
+      - id: detect
+        name: Check private suite credentials
+        run: |
+          if [ -n "$BLACKBOX_REPOSITORY" ] && [ -n "$BLACKBOX_SSH_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Blackbox configuration not present; skipping private package validation."
+          fi
+
   package-blackbox:
     name: Package blackbox tests
     runs-on: ubuntu-latest
+    needs: blackbox-config
+    if: needs.blackbox-config.outputs.enabled == 'true'
+    timeout-minutes: 20
     env:
       TACHYON_PACKAGE_TARBALL: /tmp/tachyon-blackbox.tgz
+      BLACKBOX_REPOSITORY: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
 
     steps:
       - name: Checkout
@@ -64,25 +98,22 @@ jobs:
         run: bun pm pack --filename "$TACHYON_PACKAGE_TARBALL" --quiet
 
       - name: Require private blackbox credentials
-        env:
-          BLACKBOX_REPOSITORY: ${{ vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY }}
-          BLACKBOX_SSH_KEY: ${{ secrets.BLACKBOX_SSH_KEY }}
         run: |
           if [ -z "$BLACKBOX_REPOSITORY" ]; then
-            echo "::error::Missing BLACKBOX_REPOSITORY variable or secret"
+            echo "::error::Missing TACHYON_BLACKBOX_REPOSITORY, BLACKBOX_REPOSITORY, or NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
             exit 1
           fi
           if [ -z "$BLACKBOX_SSH_KEY" ]; then
-            echo "::error::Missing BLACKBOX_SSH_KEY secret"
+            echo "::error::Missing TACHYON_BLACKBOX_SSH_KEY, BLACKBOX_SSH_KEY, or NIGHTJAR_BLACKBOX_SSH_KEY secret"
             exit 1
           fi
 
       - name: Checkout private blackbox suite
         uses: actions/checkout@v6
         with:
-          repository: ${{ vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY }}
-          ssh-key: ${{ secrets.BLACKBOX_SSH_KEY }}
-          ref: ${{ vars.TACHYON_BLACKBOX_REF || 'main' }}
+          repository: ${{ env.BLACKBOX_REPOSITORY }}
+          ssh-key: ${{ env.BLACKBOX_SSH_KEY }}
+          ref: ${{ vars.TACHYON_BLACKBOX_REF || vars.BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
           path: .blackbox-tests
 
       - name: Run Tachyon blackbox tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,10 +5,19 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: release-${{ github.repository }}
+  cancel-in-progress: false
+
 jobs:
   test:
     name: Test before publish
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -37,11 +46,36 @@ jobs:
           HOSTNAME: 127.0.0.1
           BASIC_AUTH: admin:pass
 
+  blackbox-config:
+    name: Detect blackbox configuration
+    runs-on: ubuntu-latest
+    outputs:
+      enabled: ${{ steps.detect.outputs.enabled }}
+    env:
+      BLACKBOX_REPOSITORY: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
+
+    steps:
+      - id: detect
+        name: Check private suite credentials
+        run: |
+          if [ -n "$BLACKBOX_REPOSITORY" ] && [ -n "$BLACKBOX_SSH_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "Blackbox configuration not present; skipping private package validation."
+          fi
+
   package-blackbox:
     name: Package blackbox tests
     runs-on: ubuntu-latest
+    needs: blackbox-config
+    if: needs.blackbox-config.outputs.enabled == 'true'
+    timeout-minutes: 20
     env:
       TACHYON_PACKAGE_TARBALL: /tmp/tachyon-blackbox.tgz
+      BLACKBOX_REPOSITORY: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
+      BLACKBOX_SSH_KEY: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
 
     steps:
       - name: Checkout
@@ -59,25 +93,22 @@ jobs:
         run: bun pm pack --filename "$TACHYON_PACKAGE_TARBALL" --quiet
 
       - name: Require private blackbox credentials
-        env:
-          BLACKBOX_REPOSITORY: ${{ vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY }}
-          BLACKBOX_SSH_KEY: ${{ secrets.BLACKBOX_SSH_KEY }}
         run: |
           if [ -z "$BLACKBOX_REPOSITORY" ]; then
-            echo "::error::Missing BLACKBOX_REPOSITORY variable or secret"
+            echo "::error::Missing TACHYON_BLACKBOX_REPOSITORY, BLACKBOX_REPOSITORY, or NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
             exit 1
           fi
           if [ -z "$BLACKBOX_SSH_KEY" ]; then
-            echo "::error::Missing BLACKBOX_SSH_KEY secret"
+            echo "::error::Missing TACHYON_BLACKBOX_SSH_KEY, BLACKBOX_SSH_KEY, or NIGHTJAR_BLACKBOX_SSH_KEY secret"
             exit 1
           fi
 
       - name: Checkout private blackbox suite
         uses: actions/checkout@v6
         with:
-          repository: ${{ vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY }}
-          ssh-key: ${{ secrets.BLACKBOX_SSH_KEY }}
-          ref: ${{ vars.TACHYON_BLACKBOX_REF || 'main' }}
+          repository: ${{ env.BLACKBOX_REPOSITORY }}
+          ssh-key: ${{ env.BLACKBOX_SSH_KEY }}
+          ref: ${{ vars.TACHYON_BLACKBOX_REF || vars.BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
           path: .blackbox-tests
 
       - name: Run Tachyon blackbox tests
@@ -131,11 +162,13 @@ jobs:
   publish:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
-    needs: [test, package-blackbox, version]
-    if: needs.version.outputs.tag_exists == 'false'
+    needs: [test, blackbox-config, package-blackbox, version]
+    if: needs.version.outputs.tag_exists == 'false' && (needs.blackbox-config.outputs.enabled == 'false' || needs.package-blackbox.result == 'success')
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write
+    environment: packages-prod
 
     steps:
       - name: Checkout
@@ -166,6 +199,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [version, publish]
     if: needs.version.outputs.tag_exists == 'false'
+    timeout-minutes: 10
     permissions:
       contents: write
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -163,7 +163,18 @@ jobs:
     name: Publish to GitHub Packages
     runs-on: ubuntu-latest
     needs: [test, blackbox-config, package-blackbox, version]
-    if: needs.version.outputs.tag_exists == 'false' && (needs.blackbox-config.outputs.enabled == 'false' || needs.package-blackbox.result == 'success')
+    if: >-
+      ${{
+        always() &&
+        needs.test.result == 'success' &&
+        needs.blackbox-config.result == 'success' &&
+        needs.version.result == 'success' &&
+        needs.version.outputs.tag_exists == 'false' &&
+        (
+          needs.blackbox-config.outputs.enabled == 'false' ||
+          needs.package-blackbox.result == 'success'
+        )
+      }}
     timeout-minutes: 15
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- add explicit workflow permissions, concurrency, and timeouts to Tachyon CI/publish flows
- make package blackbox validation conditional on configured credentials instead of hard-failing when secrets are absent
- add fallback support for repo-specific, shared, and NightJar blackbox credentials
- gate package publishing behind the `packages-prod` environment

## Why
Tachyon already has a stronger workflow baseline than FYLO, but it still lacked environment-gated publishing and had a mandatory blackbox path that could block the release flow unnecessarily when credentials were not present.

## Validation
- workflow-only change; GitHub Actions on this PR should be treated as source of truth
- local desktop verification was intentionally limited because this repo currently needs Linux-side checkout handling for Windows-incompatible route filenames

## Follow-up
- the open runtime issue about async handler rerenders is intentionally out of scope for this CI/CD hardening PR
- once the PR is proven, confirm the `packages-prod` reviewer configuration if stricter publish approval is desired
