### PR TITLE
ci: fix v2.0.0 publish 403 (write-scoped GITHUB_TOKEN)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -247,12 +247,12 @@ jobs:
           d31ma = { url = "https://npm.pkg.github.com", token = "$NODE_AUTH_TOKEN" }
           EOF
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
+          NODE_AUTH_TOKEN: ${{ github.token }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
+          NODE_AUTH_TOKEN: ${{ github.token }}
 
       - name: Setup Node
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- Publish job's Configure step was baking `secrets.PACKAGES_READ_TOKEN` into the project-level `.npmrc`. That read-only PAT then beat the publish step's write-scoped `github.token`, causing `403 "token provided does not match expected scopes"` on `npm publish`.
- Switch the publish job's `Configure` and `Install` steps to `${{ github.token }}` directly. The publish job already has `packages: write` via job-level permissions, so it works for both install (fylo read) and publish (tachyon write).
- Other jobs keep the `PACKAGES_READ_TOKEN` fallback — they only need read.

## Context
- v2.0.0 merged in [#38](https://github.com/d31ma/Tachyon/pull/38); publish workflow failed on the `Publish to GitHub Packages` step ([run 24873980005](https://github.com/d31ma/Tachyon/actions/runs/24873980005)).
- `v2.0.0` tag was not created, so merging this will re-run the publish workflow cleanly and then tag + release.

## Test plan
- [ ] CI checks pass on this PR
- [ ] Merge triggers publish.yml on main
- [ ] `@d31ma/tachyon@2.0.0` appears on GitHub Packages
- [ ] `v2.0.0` tag and GitHub release are created