### PR TITLE
Use FOUNDRY for GitHub Packages publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -243,7 +243,6 @@ jobs:
 
   publish:
     name: Publish to GitHub Packages
-    runs-on: ubuntu-latest
     needs: [test, blackbox-config, package-blackbox, version]
     if: >-
       ${{
@@ -258,6 +257,7 @@ jobs:
           needs.package-blackbox.result == 'success'
         )
       }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
@@ -265,52 +265,14 @@ jobs:
     environment: packages-prod
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+      - name: Publish via FOUNDRY
+        uses: d31ma/FOUNDRY/.github/actions/publish-github-package@main
         with:
-          bun-version: latest
-
-      - name: Configure GitHub Packages
-        run: |
-          {
-            echo "@d31ma:registry=https://npm.pkg.github.com"
-            echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}"
-            echo "always-auth=true"
-          } > .npmrc
-          cp .npmrc ~/.npmrc
-          cat >> bunfig.toml <<'EOF'
-
-          [install.scopes]
-          "@d31ma" = { url = "https://npm.pkg.github.com", token = "$NODE_AUTH_TOKEN" }
-          EOF
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@d31ma'
-
-      - name: Publish to GitHub Packages
-        run: |
-          {
-            echo "@d31ma:registry=https://npm.pkg.github.com"
-            echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}"
-            echo "always-auth=true"
-          } > .npmrc
-          npm publish --tag beta --registry=https://npm.pkg.github.com
-        env:
-          NODE_AUTH_TOKEN: ${{ github.token }}
+          package_name: ${{ needs.version.outputs.package_name }}
+          version: ${{ needs.version.outputs.version }}
+          github_dist_tag: beta
+          publish_token: ${{ github.token }}
+          packages_read_token: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
 
   promote-npm:
     name: Promote to npm registry


### PR DESCRIPTION
## Summary\n- replace the inline GitHub Packages publish steps with the shared FOUNDRY publish action\n- keep repo-local validation, blackbox gating, packages-prod environment, and npm promotion flow intact\n- keep Tachyon's private package install token path through the action's packages_read_token input\n\n## Verification\n- ruby YAML parse for .github/workflows/publish.yml