### PR TITLE
Move Tachyon behavior contracts into package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,104 +65,13 @@ jobs:
 
       - name: Run tests
         if: matrix.bun-version != 'latest'
-        run: bun test
+        run: bun run test
         env:
           HOSTNAME: 127.0.0.1
           BASIC_AUTH: admin:pass
 
-  blackbox-config:
-    name: Detect blackbox configuration
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.detect.outputs.enabled }}
-    env:
-      BLACKBOX_REPOSITORY: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
-
-    steps:
-      - id: detect
-        name: Check private suite credentials
-        run: |
-          if [ -n "$BLACKBOX_REPOSITORY" ] && [ -n "$BLACKBOX_SSH_KEY" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "Blackbox configuration not present; skipping private package validation."
-          fi
-
-  package-blackbox:
-    name: Package blackbox tests
-    runs-on: ubuntu-latest
-    needs: blackbox-config
-    if: needs.blackbox-config.outputs.enabled == 'true'
-    timeout-minutes: 20
-    env:
-      TACHYON_PACKAGE_TARBALL: /tmp/tachyon-blackbox.tgz
-      BLACKBOX_REPOSITORY: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Configure npm registry
-        run: |
-          {
-            echo "@d31ma:registry=https://registry.npmjs.org/"
-          } > .npmrc
-          cp .npmrc ~/.npmrc
-          cat >> bunfig.toml <<'EOF'
-
-          [install.scopes]
-          "@d31ma" = { url = "https://registry.npmjs.org/" }
-          EOF
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Pack package under test
-        run: bun pm pack --filename "$TACHYON_PACKAGE_TARBALL" --quiet
-
-      - name: Require private blackbox credentials
-        run: |
-          if [ -z "$BLACKBOX_REPOSITORY" ]; then
-            echo "::error::Missing TACHYON_BLACKBOX_REPOSITORY, BLACKBOX_REPOSITORY, or NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
-            exit 1
-          fi
-          if [ -z "$BLACKBOX_SSH_KEY" ]; then
-            echo "::error::Missing TACHYON_BLACKBOX_SSH_KEY, BLACKBOX_SSH_KEY, or NIGHTJAR_BLACKBOX_SSH_KEY secret"
-            exit 1
-          fi
-
-      - name: Checkout private blackbox suite
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.BLACKBOX_REPOSITORY }}
-          ssh-key: ${{ env.BLACKBOX_SSH_KEY }}
-          ref: ${{ vars.TACHYON_BLACKBOX_REF || vars.BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
-          path: .blackbox-tests
-
-      - name: Run Tachyon blackbox tests
-        working-directory: .blackbox-tests
+      - name: Run package blackbox tests
+        if: matrix.bun-version == 'latest'
+        run: bun run test:blackbox
         env:
-          NIGHTJAR_SUITE: tachyon
-          TACHYON_PACKAGE_TARBALL: ${{ env.TACHYON_PACKAGE_TARBALL }}
           NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
-        run: |
-          export NPM_CONFIG_USERCONFIG="$GITHUB_WORKSPACE/.npmrc"
-          export npm_config_userconfig="$GITHUB_WORKSPACE/.npmrc"
-
-          if [ -f package.json ] || [ -f bun.lock ]; then
-            bun install --frozen-lockfile
-          fi
-
-          if [ -f package.json ] && jq -e '.scripts.blackbox' package.json >/dev/null; then
-            bun run blackbox
-          else
-            bun test tachyon --timeout 120000
-          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,101 +58,8 @@ jobs:
           HOSTNAME: 127.0.0.1
           BASIC_AUTH: admin:pass
 
-  blackbox-config:
-    name: Detect blackbox configuration
-    runs-on: ubuntu-latest
-    outputs:
-      enabled: ${{ steps.detect.outputs.enabled }}
-    env:
-      BLACKBOX_REPOSITORY: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
-
-    steps:
-      - id: detect
-        name: Check private suite credentials
-        run: |
-          if [ -n "$BLACKBOX_REPOSITORY" ] && [ -n "$BLACKBOX_SSH_KEY" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "Blackbox configuration not present; skipping private package validation."
-          fi
-
-  package-blackbox:
-    name: Package blackbox tests
-    runs-on: ubuntu-latest
-    needs: blackbox-config
-    if: needs.blackbox-config.outputs.enabled == 'true'
-    timeout-minutes: 20
-    env:
-      TACHYON_PACKAGE_TARBALL: /tmp/tachyon-blackbox.tgz
-      BLACKBOX_REPOSITORY: ${{ vars.TACHYON_BLACKBOX_REPOSITORY || secrets.TACHYON_BLACKBOX_REPOSITORY || vars.BLACKBOX_REPOSITORY || secrets.BLACKBOX_REPOSITORY || vars.NIGHTJAR_BLACKBOX_REPOSITORY || secrets.NIGHTJAR_BLACKBOX_REPOSITORY }}
-      BLACKBOX_SSH_KEY: ${{ secrets.TACHYON_BLACKBOX_SSH_KEY || secrets.BLACKBOX_SSH_KEY || secrets.NIGHTJAR_BLACKBOX_SSH_KEY }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Configure npm registry
-        run: |
-          {
-            echo "@d31ma:registry=https://registry.npmjs.org/"
-          } > .npmrc
-          cp .npmrc ~/.npmrc
-          cat >> bunfig.toml <<'EOF'
-
-          [install.scopes]
-          "@d31ma" = { url = "https://registry.npmjs.org/" }
-          EOF
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Pack package under test
-        run: bun pm pack --filename "$TACHYON_PACKAGE_TARBALL" --quiet
-
-      - name: Require private blackbox credentials
-        run: |
-          if [ -z "$BLACKBOX_REPOSITORY" ]; then
-            echo "::error::Missing TACHYON_BLACKBOX_REPOSITORY, BLACKBOX_REPOSITORY, or NIGHTJAR_BLACKBOX_REPOSITORY variable or secret"
-            exit 1
-          fi
-          if [ -z "$BLACKBOX_SSH_KEY" ]; then
-            echo "::error::Missing TACHYON_BLACKBOX_SSH_KEY, BLACKBOX_SSH_KEY, or NIGHTJAR_BLACKBOX_SSH_KEY secret"
-            exit 1
-          fi
-
-      - name: Checkout private blackbox suite
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ env.BLACKBOX_REPOSITORY }}
-          ssh-key: ${{ env.BLACKBOX_SSH_KEY }}
-          ref: ${{ vars.TACHYON_BLACKBOX_REF || vars.BLACKBOX_REF || vars.NIGHTJAR_BLACKBOX_REF || 'main' }}
-          path: .blackbox-tests
-
-      - name: Run Tachyon behavior blackbox tests
-        working-directory: .blackbox-tests
-        env:
-          NIGHTJAR_SUITE: tachyon
-          TACHYON_PACKAGE_TARBALL: ${{ env.TACHYON_PACKAGE_TARBALL }}
-          NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
-        run: |
-          export NPM_CONFIG_USERCONFIG="$GITHUB_WORKSPACE/.npmrc"
-          export npm_config_userconfig="$GITHUB_WORKSPACE/.npmrc"
-
-          if [ -f package.json ] || [ -f bun.lock ]; then
-            bun install --frozen-lockfile
-          fi
-
-          bun test tachyon/yon-contract.test.mjs tachyon/serve-contract.test.mjs --timeout 120000
-
-      - name: Run Tachyon package contract
-        run: bun run scripts/verify-package-contract.js
+      - name: Run package blackbox tests
+        run: bun run test:blackbox
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PACKAGES_READ_TOKEN || github.token }}
 
@@ -229,19 +136,14 @@ jobs:
 
   publish:
     name: Publish to GitHub Packages
-    needs: [test, blackbox-config, package-blackbox, version]
+    needs: [test, version]
     if: >-
       ${{
         always() &&
         needs.test.result == 'success' &&
-        needs.blackbox-config.result == 'success' &&
         needs.version.result == 'success' &&
         needs.version.outputs.tag_exists == 'false' &&
-        needs.version.outputs.github_version_exists == 'false' &&
-        (
-          needs.blackbox-config.outputs.enabled == 'false' ||
-          needs.package-blackbox.result == 'success'
-        )
+        needs.version.outputs.github_version_exists == 'false'
       }}
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/package-contract/helpers.mjs
+++ b/package-contract/helpers.mjs
@@ -1,0 +1,164 @@
+import { randomBytes } from 'node:crypto'
+import { access, chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtempSync, rmSync } from 'node:fs'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { spawnSync } from 'node:child_process'
+
+const repoRoot = path.resolve(fileURLToPath(new URL('..', import.meta.url)))
+const packageTempRoot = mkdtempSync(path.join(os.tmpdir(), 'tachyon-package-'))
+let packedTarball
+
+process.on('exit', () => {
+  rmSync(packageTempRoot, { recursive: true, force: true })
+})
+
+export function uniqueName(prefix = 'tachyon') {
+  return `${prefix}-${Date.now()}-${randomBytes(3).toString('hex')}`
+}
+
+export function run(command, args, { cwd, env = {}, timeout = 120_000 } = {}) {
+  const result = spawnSync(command, args, {
+    cwd,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+    timeout,
+  })
+
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    error: result.error,
+  }
+}
+
+export function assertRun(result, label) {
+  if (result.status === 0 && !result.error) return
+
+  throw new Error(
+    [
+      `${label} failed with status ${result.status}`,
+      result.error ? `error: ${result.error.message}` : undefined,
+      result.stdout ? `stdout:\n${result.stdout}` : undefined,
+      result.stderr ? `stderr:\n${result.stderr}` : undefined,
+    ]
+      .filter(Boolean)
+      .join('\n\n')
+  )
+}
+
+export function tachyonTarball() {
+  if (process.env.TACHYON_PACKAGE_TARBALL) return process.env.TACHYON_PACKAGE_TARBALL
+  if (packedTarball) return packedTarball
+
+  const tarball = path.join(packageTempRoot, `${uniqueName('tachyon-package')}.tgz`)
+  const pack = run('bun', ['pm', 'pack', '--filename', tarball, '--quiet'], {
+    cwd: repoRoot,
+  })
+  assertRun(pack, `bun pm pack --filename ${tarball}`)
+  packedTarball = tarball
+  return packedTarball
+}
+
+async function copyIfExists(source, destination) {
+  try {
+    await access(source)
+  } catch (error) {
+    if (error?.code === 'ENOENT') return
+    throw error
+  }
+  await copyFile(source, destination)
+}
+
+export async function createTachyonApp() {
+  const tarball = tachyonTarball()
+  const root = await mkdtemp(path.join(os.tmpdir(), 'tachyon-app-'))
+
+  await writeFile(
+    path.join(root, 'package.json'),
+    JSON.stringify(
+      {
+        private: true,
+        type: 'module',
+        scripts: {
+          bundle: 'tac.bundle',
+          serve: 'yon.serve',
+          preview: 'tac.preview',
+        },
+      },
+      null,
+      2
+    )
+  )
+
+  await copyIfExists(path.join(repoRoot, '.npmrc'), path.join(root, '.npmrc'))
+
+  const install = run('bun', ['add', tarball], { cwd: root })
+  assertRun(install, `bun add ${tarball}`)
+
+  return {
+    root,
+    bin(name) {
+      return path.join(root, 'node_modules', '.bin', name)
+    },
+    runBin(name, args = [], options = {}) {
+      const result = run('bun', [this.bin(name), ...args], {
+        cwd: options.cwd ?? root,
+        env: options.env,
+        timeout: options.timeout,
+      })
+      assertRun(result, `bun ${name} ${args.join(' ')}`.trim())
+      return result
+    },
+    async writeFile(relativePath, content, mode) {
+      const filePath = path.join(root, relativePath)
+      await mkdir(path.dirname(filePath), { recursive: true })
+      await writeFile(filePath, content)
+      if (mode) await chmod(filePath, mode)
+      return filePath
+    },
+    async readFile(relativePath) {
+      return readFile(path.join(root, relativePath), 'utf8')
+    },
+    async cleanup() {
+      await rm(root, { recursive: true, force: true })
+    },
+  }
+}
+
+export async function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        server.close()
+        reject(new Error('Failed to resolve an ephemeral port'))
+        return
+      }
+      server.close((error) => error ? reject(error) : resolve(address.port))
+    })
+  })
+}
+
+export async function waitFor(check, { timeoutMs = 20_000, intervalMs = 200 } = {}) {
+  const startedAt = Date.now()
+  while (Date.now() - startedAt < timeoutMs) {
+    if (await check()) return true
+    await Bun.sleep(intervalMs)
+  }
+  return false
+}
+
+export function startTachyon(app, { args = [], env = {} } = {}) {
+  return Bun.spawn(['bun', app.bin('yon.serve'), ...args], {
+    cwd: app.root,
+    env: { ...process.env, ...env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+}

--- a/package-contract/serve-contract.test.mjs
+++ b/package-contract/serve-contract.test.mjs
@@ -1,0 +1,110 @@
+import { afterEach, expect, test } from 'bun:test'
+import { createTachyonApp, getFreePort, startTachyon, waitFor } from './helpers.mjs'
+
+const apps = []
+const processes = []
+
+afterEach(async () => {
+  for (const proc of processes.splice(0)) {
+    proc.kill()
+    await proc.exited.catch(() => {})
+  }
+
+  await Promise.all(apps.splice(0).map((app) => app.cleanup()))
+})
+
+test('yon.serve handles API requests with request ids and JSON bodies', async () => {
+  const app = await createTachyonApp()
+  apps.push(app)
+
+  await app.writeFile('server/routes/api/POST.js', [
+    'export function handler(input) {',
+    '  return {',
+    '    ok: true,',
+    '    body: input.body,',
+    '    requestId: input.context.requestId,',
+    '    query: input.query,',
+    '  }',
+    '}',
+  ].join('\n'))
+
+  const port = await getFreePort()
+  const proc = startTachyon(app, {
+    env: {
+      YON_PORT: String(port),
+      YON_HOST: '127.0.0.1',
+      YON_LOG_FORMAT: 'json',
+    },
+  })
+  processes.push(proc)
+
+  const baseUrl = `http://127.0.0.1:${port}`
+  const ready = await waitFor(async () => {
+    try {
+      const res = await fetch(`${baseUrl}/health`)
+      return res.ok
+    } catch {
+      return false
+    }
+  })
+  expect(ready).toBe(true)
+
+  const res = await fetch(`${baseUrl}/api?count=2&enabled=true`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Request-Id': 'package-contract-request-id',
+    },
+    body: JSON.stringify({ name: 'Tachyon' }),
+  })
+  const body = await res.json()
+
+  expect(res.status).toBe(200)
+  expect(res.headers.get('x-request-id')).toBe('package-contract-request-id')
+  expect(body.ok).toBe(true)
+  expect(body.requestId).toBe('package-contract-request-id')
+  expect(body.body.name).toBe('Tachyon')
+  expect(body.query.count).toBe(2)
+  expect(body.query.enabled).toBe(true)
+})
+
+test('production HTML fallback does not inject the development HMR client', async () => {
+  const app = await createTachyonApp()
+  apps.push(app)
+
+  await app.writeFile('browser/pages/index.html', '<main>Production shell</main>')
+
+  const port = await getFreePort()
+  const proc = startTachyon(app, {
+    env: {
+      YON_PORT: String(port),
+      YON_HOST: '127.0.0.1',
+      NODE_ENV: 'production',
+    },
+  })
+  processes.push(proc)
+
+  const baseUrl = `http://127.0.0.1:${port}`
+  const ready = await waitFor(async () => {
+    try {
+      const res = await fetch(`${baseUrl}/`, { headers: { Accept: 'text/html' } })
+      return res.ok
+    } catch {
+      return false
+    }
+  })
+  expect(ready).toBe(true)
+
+  const htmlRes = await fetch(`${baseUrl}/`, { headers: { Accept: 'text/html' } })
+  const html = await htmlRes.text()
+  const clientRes = await fetch(`${baseUrl}/hot-reload-client.js`)
+  const clientCode = await clientRes.text()
+
+  expect(htmlRes.status).toBe(200)
+  expect(html).toContain('/spa-renderer.js')
+  expect(html).not.toContain('/hot-reload-client.js')
+  expect(clientRes.status).toBe(200)
+  expect(clientCode).toContain('.ok')
+  expect(clientCode).toContain('event:')
+  expect(clientCode).toContain('reload')
+})

--- a/package-contract/tac-contract.test.mjs
+++ b/package-contract/tac-contract.test.mjs
@@ -1,0 +1,70 @@
+import { afterEach, expect, test } from 'bun:test'
+import { pathToFileURL } from 'node:url'
+import path from 'node:path'
+import { createTachyonApp } from './helpers.mjs'
+
+const apps = []
+
+afterEach(async () => {
+  await Promise.all(apps.splice(0).map((app) => app.cleanup()))
+})
+
+test('tac.bundle prerenders component pages and supports global Tac output', async () => {
+  const app = await createTachyonApp()
+  apps.push(app)
+
+  await app.writeFile('browser/components/status-card.html', '<script>let label = ""</script><strong>Status: {label}</strong>')
+  await app.writeFile('browser/pages/index.html', [
+    '<script>',
+    "  let label = 'green'",
+    '</script>',
+    '<status-card :label="label" />',
+    '<package-contract-widget data-source="blackbox"></package-contract-widget>',
+  ].join('\n'))
+
+  app.runBin('tac.bundle', [], { env: { TAC_FORMAT: 'global' } })
+
+  const html = await app.readFile('dist/index.html')
+  const pageModule = await app.readFile('dist/pages/index.js')
+  const componentModule = await app.readFile('dist/components/status-card.js')
+
+  expect(html).toContain('Status: green')
+  expect(html).toContain('<package-contract-widget')
+  expect(pageModule).toContain('register("/pages/index.js"')
+  expect(componentModule).toContain('register("/components/status-card.js"')
+  expect(pageModule).not.toContain('export default')
+})
+
+test('async Tac event handlers are awaited before rerender output is produced', async () => {
+  const app = await createTachyonApp()
+  apps.push(app)
+
+  await app.writeFile('browser/pages/index.html', [
+    '<script>',
+    "let status = 'idle';",
+    'async function requestMfa() {',
+    "  status = 'loading';",
+    '  await Promise.resolve();',
+    "  status = 'phone-input';",
+    '}',
+    '</script>',
+    '<button @click="requestMfa()">Continue</button>',
+    '<p>{status}</p>',
+  ].join('\n'))
+
+  app.runBin('tac.bundle')
+
+  const modulePath = path.join(app.root, 'dist', 'pages', 'index.js')
+  const pageModule = await import(`${pathToFileURL(modulePath).href}?contract=${Date.now()}`)
+  const render = await pageModule.default()
+  const initial = await render()
+  const buttonId = initial.match(/<button[^>]* id="([^"]+)"/)?.[1]
+
+  expect(buttonId).toBeDefined()
+  expect(initial).toContain('>idle</p>')
+
+  const updated = await render(buttonId)
+
+  expect(updated).toContain('>phone-input</p>')
+  expect(updated).not.toContain('>loading</p>')
+})

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
         "bundle:watch": "bun src/cli/bundle.js --watch",
         "start": "bun run serve",
         "typecheck": "tsc --noEmit",
-        "test": "bun --env-file=.env.test test",
-        "test:coverage": "bun --env-file=.env.test test --coverage"
+        "test": "bun --env-file=.env.test test tests",
+        "test:blackbox": "bun run scripts/verify-package-contract.js && bun test package-contract --timeout 120000",
+        "test:coverage": "bun --env-file=.env.test test tests --coverage"
     },
     "files": [
         "bin/",


### PR DESCRIPTION
## Summary
- add repo-local Tachyon package contracts for yon.serve and tac.bundle behavior
- run package contracts directly from CI and publish
- remove the private NightJar checkout from Tachyon workflows
- rebase onto current main, preserving the npm-registry install path and Tachyon 26.19.05 package state

## Verification
- bun install --frozen-lockfile
- cd examples && bun install --frozen-lockfile
- bun run typecheck
- bun run test:blackbox