### PR TITLE
release: 26.19.07 — route validation hardening and prerender fix

### DIFF
--- a/examples/server/routes/languages/javascript/GET.js
+++ b/examples/server/routes/languages/javascript/GET.js
@@ -1,4 +1,4 @@
-import LanguageService from '../../../services/language-service.js';
+import LanguageService from '@/services/language-service.js';
 
 const service = new LanguageService();
 

--- a/examples/server/routes/languages/javascript/POST.js
+++ b/examples/server/routes/languages/javascript/POST.js
@@ -1,4 +1,4 @@
-import LanguageService from '../../../services/language-service.js';
+import LanguageService from '@/services/language-service.js';
 
 const service = new LanguageService();
 

--- a/examples/server/routes/languages/javascript/PUT.js
+++ b/examples/server/routes/languages/javascript/PUT.js
@@ -1,4 +1,4 @@
-import LanguageService from '../../../services/language-service.js';
+import LanguageService from '@/services/language-service.js';
 
 const service = new LanguageService();
 

--- a/examples/server/routes/languages/javascript/telemetry/GET.js
+++ b/examples/server/routes/languages/javascript/telemetry/GET.js
@@ -1,4 +1,4 @@
-import TelemetryService from '../../../../services/telemetry-service.js'
+import TelemetryService from '@/services/telemetry-service.js'
 
 const service = new TelemetryService()
 

--- a/examples/server/routes/languages/typescript/GET.ts
+++ b/examples/server/routes/languages/typescript/GET.ts
@@ -1,4 +1,4 @@
-import TypeScriptLanguageService, { type YonRequest } from '../../../services/typescript-language-service.ts'
+import TypeScriptLanguageService, { type YonRequest } from '@/services/typescript-language-service.ts'
 
 const service = new TypeScriptLanguageService()
 

--- a/examples/server/routes/languages/typescript/items/DELETE.ts
+++ b/examples/server/routes/languages/typescript/items/DELETE.ts
@@ -1,4 +1,4 @@
-import ItemService from '../../../../services/item-service.ts'
+import ItemService from '@/services/item-service.ts'
 
 const service = new ItemService()
 

--- a/examples/server/routes/languages/typescript/items/GET.ts
+++ b/examples/server/routes/languages/typescript/items/GET.ts
@@ -1,4 +1,4 @@
-import ItemService from '../../../../services/item-service.ts'
+import ItemService from '@/services/item-service.ts'
 
 const service = new ItemService()
 

--- a/examples/server/routes/languages/typescript/items/POST.ts
+++ b/examples/server/routes/languages/typescript/items/POST.ts
@@ -1,4 +1,4 @@
-import ItemService from '../../../../services/item-service.ts'
+import ItemService from '@/services/item-service.ts'
 
 type YonRequest = {
   body?: unknown

--- a/examples/server/routes/languages/typescript/items/_id/DELETE.ts
+++ b/examples/server/routes/languages/typescript/items/_id/DELETE.ts
@@ -1,4 +1,4 @@
-import ItemService from '../../../../../services/item-service.ts'
+import ItemService from '@/services/item-service.ts'
 
 type YonRequest = {
   paths?: {

--- a/examples/server/routes/languages/typescript/items/_id/GET.ts
+++ b/examples/server/routes/languages/typescript/items/_id/GET.ts
@@ -1,4 +1,4 @@
-import ItemService from '../../../../../services/item-service.ts'
+import ItemService from '@/services/item-service.ts'
 
 type YonRequest = {
   paths?: {

--- a/examples/server/routes/languages/typescript/items/_id/PATCH.ts
+++ b/examples/server/routes/languages/typescript/items/_id/PATCH.ts
@@ -1,4 +1,4 @@
-import ItemService from '../../../../../services/item-service.ts'
+import ItemService from '@/services/item-service.ts'
 
 type YonRequest = {
   body?: unknown

--- a/examples/server/routes/languages/typescript/items/_id/PUT.ts
+++ b/examples/server/routes/languages/typescript/items/_id/PUT.ts
@@ -1,4 +1,4 @@
-import ItemService from '../../../../../services/item-service.ts'
+import ItemService from '@/services/item-service.ts'
 
 type YonRequest = {
   body?: unknown

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -15,7 +15,10 @@
     "allowImportingTsExtensions": true,
     "maxNodeModuleJsDepth": 0,
     "skipLibCheck": true,
-    "noUncheckedSideEffectImports": false
+    "noUncheckedSideEffectImports": false,
+    "paths": {
+      "@/*": ["./examples/server/*"]
+    }
   },
   "include": [
     "src/**/*.d.ts",

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -350,7 +350,7 @@ export default class Compiler {
     static pageModuleFilePath(distPath, pathname) {
         return pathname === '/'
             ? path.join(distPath, 'pages', 'index.js')
-            : path.join(distPath, 'pages', pathname.slice(1), 'index.js');
+            : path.join(distPath, 'pages', Router.routeToFilesystemPath(pathname).slice(1), 'index.js');
     }
 
     /** @param {string | undefined} scriptLang */

--- a/src/server/http/route-handler.js
+++ b/src/server/http/route-handler.js
@@ -331,6 +331,14 @@ export default class Router {
         if (routeMethod) {
             Router.allRoutes.get(route)?.add(routeMethod);
             Router.routeHandlers[route] ??= {};
+            if (Router.routeHandlers[route][routeMethod]) {
+                const existing = path.posix.basename(Router.routeHandlers[route][routeMethod]);
+                const incoming = path.posix.basename(routeFilePath);
+                throw new Error(
+                    `Duplicate ${routeMethod} handler for '${route}' — both '${existing}' and '${incoming}' exist. ` +
+                    `Remove one so only a single handler file remains per route and method.`
+                );
+            }
             Router.routeHandlers[route][routeMethod] = path.join(Router.routesPath, routeFilePath);
         }
         if (await routeOptionsFile.exists() && !Router.routeConfigs[route]) {


### PR DESCRIPTION
## Summary

- Duplicate route detection: validateRoute now throws a clear error when two handler files claim the same route+method, instead of silently picking one non-deterministically.
- Prerender slug fix: pageModuleFilePath now converts :slug segments to _slug via Router.routeToFilesystemPath() so prerender resolves the same paths the bundle writes. Fixes #48.
- Example path aliases: replaced deep relative imports with @/services alias in all example route handlers, added @/* mapping to jsconfig.json.

## Test plan
- Full test suite: 246 pass, 0 fail
- Typecheck: passes