### PR TITLE
release: 26.20.01 — template whitespace and component import fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@d31ma/tachyon",
-    "version": "26.19.07",
+    "version": "26.20.01",
     "description": "A polyglot, file-system-routed full-stack framework for Bun",
     "author": "Chidelma",
     "license": "MIT",

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -1114,14 +1114,11 @@ export default class Compiler {
         const seenBindings = new Set(factoryBindings);
         for (const match of renderSource.matchAll(/data-tac-module="\/components\/([^"]+)"/g)) {
             const componentPath = match[1];
-            const segments = componentPath.split('/');
-            const lastSegment = segments[segments.length - 1];
-            const dirName = segments.length > 1 ? segments[0] : lastSegment.replace(/\.[^.]+$/, '');
-            const bindingName = dirName.replaceAll('-', '_');
+            const componentName = Compiler.normalizeComponentName(componentPath.replace(/\.js$/, '.html'));
+            const bindingName = componentName.replaceAll('-', '_');
             if (!seenBindings.has(bindingName)) {
                 seenBindings.add(bindingName);
                 moduleImports.push(`${bindingName}: () => import('/components/${componentPath}')`);
-                factoryBindings.push(bindingName);
             }
         }
         const companionImportPath = data.companion?.importPath ?? data.companionImportPath;

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -1005,7 +1005,7 @@ export default class Compiler {
                     }
                 },
                 text(text) {
-                    if (text.text.trim() && !insideScript && !insideStyle) {
+                    if (text.text && !insideScript && !insideStyle) {
                         parsed.push({ element: `\`${interpolate(text.text)}\`` });
                     }
                 }
@@ -1110,6 +1110,20 @@ export default class Compiler {
         const { bindingNames: dynamicImportBindings, moduleImports: dynamicModuleImports, scriptContent, } = Compiler.liftDynamicImports(rawScriptContent);
         const moduleImports = [...dynamicModuleImports];
         const factoryBindings = [...dynamicImportBindings];
+        // Add component module imports referenced by HTML template component tags
+        const seenBindings = new Set(factoryBindings);
+        for (const match of renderSource.matchAll(/data-tac-module="\/components\/([^"]+)"/g)) {
+            const componentPath = match[1];
+            const segments = componentPath.split('/');
+            const lastSegment = segments[segments.length - 1];
+            const dirName = segments.length > 1 ? segments[0] : lastSegment.replace(/\.[^.]+$/, '');
+            const bindingName = dirName.replaceAll('-', '_');
+            if (!seenBindings.has(bindingName)) {
+                seenBindings.add(bindingName);
+                moduleImports.push(`${bindingName}: () => import('/components/${componentPath}')`);
+                factoryBindings.push(bindingName);
+            }
+        }
         const companionImportPath = data.companion?.importPath ?? data.companionImportPath;
         const companionLoader = companionImportPath
             ? `


### PR DESCRIPTION
## Summary

- **Whitespace text node preservation**: Removed the `.trim()` guard on template text nodes so whitespace between inline elements (e.g. spaces between `<span>` in code snippets) is preserved. HTML browser-level whitespace collapsing handles layout indentation. Fixes #51.
- **Component module import generation**: Scan `renderSource` for `data-tac-module` attributes after component tag processing and inject the corresponding `import()` entries so HTML template component tags are properly loaded at runtime. Fixes #52.

## Test plan

- Full test suite: 246 pass, 0 fail
- Typecheck: passes