### PR TITLE
release: 26.20.01 — fix logic else directives and component import bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@d31ma/tachyon",
-    "version": "26.20.01",
+    "version": "26.20.01-1",
     "description": "A polyglot, file-system-routed full-stack framework for Bun",
     "author": "Chidelma",
     "license": "MIT",

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -1056,8 +1056,8 @@ export default class Compiler {
         }
         let renderSource = body.join('\n')
             .replaceAll(/`<loop :for="(.*?)">`|`<\/loop>`/g, (_, expr) => expr ? `for(${expr}) {` : '}')
-            .replaceAll(/`<logic :if="(.*?)">`|`<\/logic>`/g, (_, expr) => expr ? `if(${expr}) {` : '}')
-            .replaceAll(/`<logic :else-if="(.*?)">`|`<\/logic>`/g, (_, expr) => expr ? `else if(${expr}) {` : '}')
+            .replaceAll(/`<logic :if="(.*?)">`/g, (_, expr) => `if(${expr}) {`)
+            .replaceAll(/`<logic :else-if="(.*?)">`/g, (_, expr) => `else if(${expr}) {`)
             .replaceAll(/`<logic else="">`|`<\/logic>`/g, (_, expr) => expr ? `else {` : '}');
         // Bind dynamic attributes :attr="expr" → attr="${escaped expr}"
         renderSource = renderSource.replaceAll(/:(\w[\w-]*)="([^"]*)"/g, '$1="${ty_escapeAttr($2)}"');
@@ -1118,7 +1118,7 @@ export default class Compiler {
             const bindingName = componentName.replaceAll('-', '_');
             if (!seenBindings.has(bindingName)) {
                 seenBindings.add(bindingName);
-                moduleImports.push(`${bindingName}: () => import('/components/${componentPath}')`);
+                moduleImports.push(`${bindingName}: () => import('/components/${componentPath}').then(m => m.default || m)`);
             }
         }
         const companionImportPath = data.companion?.importPath ?? data.companionImportPath;

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -1058,7 +1058,7 @@ export default class Compiler {
             .replaceAll(/`<loop :for="(.*?)">`|`<\/loop>`/g, (_, expr) => expr ? `for(${expr}) {` : '}')
             .replaceAll(/`<logic :if="(.*?)">`/g, (_, expr) => `if(${expr}) {`)
             .replaceAll(/`<logic :else-if="(.*?)">`/g, (_, expr) => `else if(${expr}) {`)
-            .replaceAll(/`<logic else="">`|`<\/logic>`/g, (_, expr) => expr ? `else {` : '}');
+            .replaceAll(/(`<logic else="">`)|(`<\/logic>`)/g, (_, expr) => expr ? `else {` : '}');
         // Bind dynamic attributes :attr="expr" → attr="${escaped expr}"
         renderSource = renderSource.replaceAll(/:(\w[\w-]*)="([^"]*)"/g, '$1="${ty_escapeAttr($2)}"');
         // Transform component invocations
@@ -1119,6 +1119,7 @@ export default class Compiler {
             if (!seenBindings.has(bindingName)) {
                 seenBindings.add(bindingName);
                 moduleImports.push(`${bindingName}: () => import('/components/${componentPath}').then(m => m.default || m)`);
+                factoryBindings.push(bindingName);
             }
         }
         const companionImportPath = data.companion?.importPath ?? data.companionImportPath;


### PR DESCRIPTION
## Summary
- Fix SyntaxError with nested `<logic else>` and `<logic :else-if>` directives by only consuming `</logic>` closing tags in the final pass (fixes #55)
- Fix component import bindings: add missing `factoryBindings` registration and unwrap `.default` from dynamic `import()` module namespace (fixes #54)

## Changes
- `src/compiler/index.js`: Remove `|</logic>` from `:if` and `:else-if` regex passes so closing tags are preserved for the final `else` pass
- `src/compiler/index.js`: Add `factoryBindings.push(bindingName)` and `.then(m => m.default || m)` to component import generation

## Test plan
- [x] `bun test` — 123 pass, 1 fail (pre-existing api-routes timeout)
- [ ] CI checks pass on push
- [ ] Verify `<logic :if/else-if/else>` chains compile correctly
- [ ] Verify component templates with dynamic imports resolve default export

🤖 Generated with [Claude Code](https://claude.com/claude-code)