### PR TITLE
release: 26.20.01-2 — fix Tac class injection and component import bindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@d31ma/tachyon",
-    "version": "26.20.01-1",
+    "version": "26.20.01-2",
     "description": "A polyglot, file-system-routed full-stack framework for Bun",
     "author": "Chidelma",
     "license": "MIT",

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -1118,7 +1118,7 @@ export default class Compiler {
             const bindingName = componentName.replaceAll('-', '_');
             if (!seenBindings.has(bindingName)) {
                 seenBindings.add(bindingName);
-                moduleImports.push(`${bindingName}: (p) => import('/components/${componentPath}').then(async (m) => { const f = m.default || m; return await f(p) })`);
+                moduleImports.push(`${bindingName}: (p) => import(${JSON.stringify(`/components/${componentPath}`)}).then(async (m) => { const f = m.default || m; return await f(p) })`);
                 factoryBindings.push(bindingName);
             }
         }
@@ -1315,6 +1315,7 @@ ${transformed}
      */
     static createCompanionScriptPlugin(sourcePath) {
         const filter = Compiler.createFilePathFilter(sourcePath);
+        const tacInline = `var __ty_noopHelpers__={isBrowser:!1,isServer:!0,bindPersistentFields:()=>{},env:(_,f)=>f,props:{},emit:()=>!1,fetch:(i,n)=>fetch(i,n),inject:(_,f)=>f,onMount:()=>{},provide:()=>{},rerender:()=>{}};class Tac{props;tac;constructor(props={},tac=__ty_noopHelpers__){this.props=props,this.tac=tac}}`;
         const decoratorsEntryPath = `${import.meta.dir}/../runtime/decorators.js`;
         const fyloGlobalEntryPath = `${import.meta.dir}/../runtime/fylo-global.js`;
         return /** @type {BunPlugin} */ ({
@@ -1333,7 +1334,6 @@ ${transformed}
                         contents = `import { fylo } from ${JSON.stringify(importPath)};\n${contents}`;
                     }
                     if (Compiler.shouldInjectTacImport(contents)) {
-                        const tacInline = `var noopHelpers={isBrowser:!1,isServer:!0,bindPersistentFields:()=>{},env:(_,f)=>f,props:{},emit:()=>!1,fetch:(i,n)=>fetch(i,n),inject:(_,f)=>f,onMount:()=>{},provide:()=>{},rerender:()=>{}};class Tac{props;tac;constructor(props={},tac=noopHelpers){this.props=props,this.tac=tac}}`;
                         contents = `${tacInline}\n${contents}`;
                     }
                     return {

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -1118,7 +1118,7 @@ export default class Compiler {
             const bindingName = componentName.replaceAll('-', '_');
             if (!seenBindings.has(bindingName)) {
                 seenBindings.add(bindingName);
-                moduleImports.push(`${bindingName}: () => import('/components/${componentPath}').then(m => m.default || m)`);
+                moduleImports.push(`${bindingName}: (p) => import('/components/${componentPath}').then(async (m) => { const f = m.default || m; return await f(p) })`);
                 factoryBindings.push(bindingName);
             }
         }
@@ -1315,7 +1315,6 @@ ${transformed}
      */
     static createCompanionScriptPlugin(sourcePath) {
         const filter = Compiler.createFilePathFilter(sourcePath);
-        const frameworkEntryPath = `${import.meta.dir}/../runtime/tac.js`;
         const decoratorsEntryPath = `${import.meta.dir}/../runtime/decorators.js`;
         const fyloGlobalEntryPath = `${import.meta.dir}/../runtime/fylo-global.js`;
         return /** @type {BunPlugin} */ ({
@@ -1334,8 +1333,8 @@ ${transformed}
                         contents = `import { fylo } from ${JSON.stringify(importPath)};\n${contents}`;
                     }
                     if (Compiler.shouldInjectTacImport(contents)) {
-                        const importPath = Compiler.toRelativeImportPath(sourcePath, frameworkEntryPath);
-                        contents = `import Tac from ${JSON.stringify(importPath)};\n${contents}`;
+                        const tacInline = `var noopHelpers={isBrowser:!1,isServer:!0,bindPersistentFields:()=>{},env:(_,f)=>f,props:{},emit:()=>!1,fetch:(i,n)=>fetch(i,n),inject:(_,f)=>f,onMount:()=>{},provide:()=>{},rerender:()=>{}};class Tac{props;tac;constructor(props={},tac=noopHelpers){this.props=props,this.tac=tac}}`;
+                        contents = `${tacInline}\n${contents}`;
                     }
                     return {
                         contents,

--- a/tests/integration/bundle-static-export.test.js
+++ b/tests/integration/bundle-static-export.test.js
@@ -745,3 +745,97 @@ timedTest('components can emit custom events handled by their parent wrapper', {
         Object.assign(globalThis, previousGlobals);
     }
 });
+
+// ── regression: issue #57 — large companion scripts must include class Tac ────
+async function createLargeCompanionFixture() {
+    const root = await mkdtemp(path.join(tmpdir(), 'tachyon-large-companion-'));
+    tempDirs.push(root);
+    await mkdir(path.join(root, 'routes'), { recursive: true });
+    await mkdir(path.join(root, 'components'), { recursive: true });
+    await writeFile(path.join(root, 'package.json'), JSON.stringify({
+        name: 'tachyon-large-companion-fixture',
+        private: true,
+    }, null, 2));
+    await writeFile(path.join(root, 'components', 'big.html'), `<strong class="big-widget">{label}</strong>`);
+    // Companion script exceeding ~1.3 KB to trigger the bundler size threshold
+    const padding = '// ' + 'x'.repeat(1500);
+    await writeFile(path.join(root, 'components', 'big.js'), `${padding}
+export default class extends Tac {
+    label = 'BigWidget'
+
+    constructor(props = {}) {
+        super(props)
+    }
+}
+`);
+    await writeFile(path.join(root, 'routes', 'index.html'), `<big />`);
+    return root;
+}
+
+timedTest('large companion scripts over 1.3KB include class Tac definition', { timeout: 20000 }, async () => {
+    const cwd = await createLargeCompanionFixture();
+    const proc = Bun.spawn(['bun', bundleEntrypoint], {
+        cwd,
+        stdout: 'pipe',
+        stderr: 'pipe'
+    });
+    const [_stdout, stderr, exitCode] = await Promise.all([
+        decode(proc.stdout),
+        decode(proc.stderr),
+        proc.exited
+    ]);
+    if (exitCode !== 0)
+        throw new Error(stderr);
+    const distComponentPath = path.join(cwd, 'dist', 'components', 'big.js');
+    const componentSource = await readFile(distComponentPath, 'utf8');
+    expect(componentSource).toContain('class Tac{');
+    expect(componentSource).toContain('extends Tac');
+});
+
+// ── regression: issue #58 — component import bindings accept props and call factory ────
+async function createComponentImportBindingFixture() {
+    const root = await mkdtemp(path.join(tmpdir(), 'tachyon-import-binding-'));
+    tempDirs.push(root);
+    await mkdir(path.join(root, 'routes'), { recursive: true });
+    await mkdir(path.join(root, 'components'), { recursive: true });
+    await writeFile(path.join(root, 'package.json'), JSON.stringify({
+        name: 'tachyon-import-binding-fixture',
+        private: true,
+    }, null, 2));
+    await writeFile(path.join(root, 'components', 'greeting.html'), `<span class="greeting">Hello {name}</span>`);
+    await writeFile(path.join(root, 'components', 'greeting.js'), `export default class extends Tac {
+    name = 'World'
+    constructor(props = {}) {
+        super(props)
+        this.name = String(this.props.name ?? 'World')
+    }
+}
+`);
+    await writeFile(path.join(root, 'routes', 'index.html'), `<greeting name="Tachyon" />`);
+    return root;
+}
+
+timedTest('page-level component import bindings accept props and call the factory', { timeout: 20000 }, async () => {
+    const cwd = await createComponentImportBindingFixture();
+    const proc = Bun.spawn(['bun', bundleEntrypoint], {
+        cwd,
+        stdout: 'pipe',
+        stderr: 'pipe'
+    });
+    const [_stdout, stderr, exitCode] = await Promise.all([
+        decode(proc.stdout),
+        decode(proc.stderr),
+        proc.exited
+    ]);
+    if (exitCode !== 0)
+        throw new Error(stderr);
+    // Verify the generated page module has the fixed binding pattern: (p) => import(...).then(async (m) => { const f = m.default || m; return await f(p) })
+    const pageModulePath = path.join(cwd, 'dist', 'pages', 'index.js');
+    const pageSource = await readFile(pageModulePath, 'utf8');
+    expect(pageSource).toMatch(/\(\w\)=>import\("[^"]+"\)\.then\(async\(\w\)=>\{/);
+    // Functional test: import and render to verify the factory is called correctly
+    const pageModule = await import(`${pathToFileURL(pageModulePath).href}?import-binding=${Date.now()}`);
+    const render = await pageModule.default();
+    const initial = await render();
+    expect(initial).toContain('Hello Tachyon');
+});


### PR DESCRIPTION
## Summary
- Fix #57: Companion plugin now injects `class Tac` and `noopHelpers` directly instead of relying on Bun's import resolution, which was size-dependent and dropped the class definition for companion scripts over ~1.3KB
- Fix #58: Component import bindings now accept props `(p) => ...` and call the factory with those props, returning the render function instead of the raw factory module
- Added regression tests for both fixes

## Test plan
- [x] Full test suite passes (252 tests, 0 failures)
- [x] New regression test: large companion scripts include `class Tac` definition
- [x] New regression test: component import bindings accept props and call factory

🤖 Generated with [Claude Code](https://claude.com/claude-code)