### PR TITLE
release: 26.20.01-3 — fix shouldInjectTacImport false positives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@d31ma/tachyon",
-    "version": "26.20.01-2",
+    "version": "26.20.01-3",
     "description": "A polyglot, file-system-routed full-stack framework for Bun",
     "author": "Chidelma",
     "license": "MIT",

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -443,7 +443,7 @@ export default class Compiler {
             .replace(/\/\*[\s\S]*?\*\//g, '')
             .replace(/\/\/.*$/gm, '')
             .replace(/(['"`])(?:\\.|(?!\1).)*\1/g, '');
-        return !(/^\s*import\b[^;]*\bTac\b/m.test(stripped)
+        return !(/^\s*import\s+(?:type\s+)?(?:\{[^}]*\bTac\b[^}]*\}|\bTac\b)/m.test(stripped)
             || /^\s*(?:const|let|var|class|function)\s+Tac\b/m.test(stripped));
     }
     /**

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -439,8 +439,12 @@ export default class Compiler {
     }
     /** @param {string} source */
     static shouldInjectTacImport(source) {
-        return !(/^\s*import\s+[\s\S]*?\bTac\b[\s\S]*?\bfrom\b/m.test(source)
-            || /^\s*(?:const|let|var|class|function)\s+Tac\b/m.test(source));
+        const stripped = source
+            .replace(/\/\*[\s\S]*?\*\//g, '')
+            .replace(/\/\/.*$/gm, '')
+            .replace(/(['"`])(?:\\.|(?!\1).)*\1/g, '');
+        return !(/^\s*import\b[^;]*\bTac\b/m.test(stripped)
+            || /^\s*(?:const|let|var|class|function)\s+Tac\b/m.test(stripped));
     }
     /**
      * Returns the subset of supported decorator names that the source uses as

--- a/tests/compiler/should-inject-tac-import.test.js
+++ b/tests/compiler/should-inject-tac-import.test.js
@@ -71,4 +71,23 @@ describe('Compiler.shouldInjectTacImport', () => {
         expect(Compiler.shouldInjectTacImport(`import { Tac } from './utils.js';\nexport default class extends Tac {}`))
             .toBe(false);
     });
+
+    test('returns true when import without semicolon does not reference Tac (TS no-semicolon)', () => {
+        const source = [
+            `import dayjs from 'dayjs'`,
+            `type InventoryItem = {`,
+            `    id: string`,
+            `    name: string`,
+            `}`,
+            `export default class extends Tac {`,
+            `    items: InventoryItem[] = []`,
+            `}`,
+        ].join('\n');
+        expect(Compiler.shouldInjectTacImport(source)).toBe(true);
+    });
+
+    test('returns false when import type Tac is present', () => {
+        expect(Compiler.shouldInjectTacImport(`import type Tac from './tac.js';\nexport default class extends Tac {}`))
+            .toBe(false);
+    });
 });

--- a/tests/compiler/should-inject-tac-import.test.js
+++ b/tests/compiler/should-inject-tac-import.test.js
@@ -1,0 +1,74 @@
+// @ts-check
+import { describe, expect, test } from 'bun:test';
+import Compiler from '../../src/compiler/index.js';
+
+describe('Compiler.shouldInjectTacImport', () => {
+    test('returns true when Tac is not imported or declared', () => {
+        expect(Compiler.shouldInjectTacImport(`export default class extends Tac {}`))
+            .toBe(true);
+    });
+
+    test('returns false when import Tac from is already present', () => {
+        expect(Compiler.shouldInjectTacImport(`import Tac from './tac.js';\nexport default class extends Tac {}`))
+            .toBe(false);
+    });
+
+    test('returns false when class Tac is locally declared', () => {
+        expect(Compiler.shouldInjectTacImport(`class Tac {}\nexport default class extends Tac {}`))
+            .toBe(false);
+    });
+
+    test('returns false when var Tac is locally declared', () => {
+        expect(Compiler.shouldInjectTacImport(`var Tac = class {};\nexport default class extends Tac {}`))
+            .toBe(false);
+    });
+
+    test('returns true when Array.from appears but no Tac import (regression for #57)', () => {
+        const source = [
+            `import { onMount } from './decorators.js';`,
+            `export default class extends Tac {`,
+            `  get folders() {`,
+            `    return Array.from(['inbox', 'archive']);`,
+            `  }`,
+            `}`,
+        ].join('\n');
+        expect(Compiler.shouldInjectTacImport(source)).toBe(true);
+    });
+
+    test('returns true when Uint8Array.from appears but no Tac import', () => {
+        const source = [
+            `import { onMount } from './decorators.js';`,
+            `export default class extends Tac {`,
+            `  decode(data) {`,
+            `    const bytes = Uint8Array.from(atob(data.contentBase64), c => c.charCodeAt(0));`,
+            `    return bytes;`,
+            `  }`,
+            `}`,
+        ].join('\n');
+        expect(Compiler.shouldInjectTacImport(source)).toBe(true);
+    });
+
+    test('returns true when Tac appears in a comment with from on a later line', () => {
+        const source = [
+            `// This component extends Tac, imported from the framework`,
+            `export default class extends Tac {`,
+            `  foo = 'bar';`,
+            `}`,
+        ].join('\n');
+        expect(Compiler.shouldInjectTacImport(source)).toBe(true);
+    });
+
+    test('returns true when Tac and from appear in string literals', () => {
+        const source = [
+            `const msg = "extends Tac from the base class";`,
+            `const note = 'Array.from is faster';`,
+            `export default class extends Tac {}`,
+        ].join('\n');
+        expect(Compiler.shouldInjectTacImport(source)).toBe(true);
+    });
+
+    test('returns false when Tac is a named import', () => {
+        expect(Compiler.shouldInjectTacImport(`import { Tac } from './utils.js';\nexport default class extends Tac {}`))
+            .toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Fix #57 (for real): The `shouldInjectTacImport` regex had a loose `[\s\S]*?\bfrom\b` pattern that false-matched on `Array.from`, `Uint8Array.from`, and other "from" references in companion scripts. This caused Tac injection to be silently skipped for larger companion files that happen to contain any `from` word after `Tac`.
- Fix strips comments, strings, and template literals before checking
- Uses `[^;]*` instead of `[\s\S]*?` to keep the match within a single import statement
- Also catches named imports like `import { Tac } from '...'`
- Adds 9 unit tests for `shouldInjectTacImport` covering all edge cases
- Fix #58 component import bindings remain from the previous release

## Root cause analysis
The original regex `/^\s*import\s+[\s\S]*?\bTac\b[\s\S]*?\bfrom\b/m` matched import statements followed by Tac and any later `from` word anywhere in the file. For large companions using `Array.from()` or `Uint8Array.from()`, this returned a false positive, causing the Tac injection to be skipped.

## Test plan
- [x] 9 new `shouldInjectTacImport` unit tests pass
- [x] Full test suite: 45 bundle+compiler tests pass
- [x] Verified on HERMES: all large components (inbox-view, email-detail, login-form, settings-view) now get `class Tac` + `__ty_noopHelpers__` injected
- [x] No old `()=>import` binding patterns remain in page output

🤖 Generated with [Claude Code](https://claude.com/claude-code)