### PR TITLE
release: 26.20.02 — scoped package resolution, exports map, OPTIONS auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@d31ma/tachyon",
-    "version": "26.20.01-3",
+    "version": "26.20.02",
     "description": "A polyglot, file-system-routed full-stack framework for Bun",
     "author": "Chidelma",
     "license": "MIT",
@@ -16,7 +16,8 @@
         "./compiler": "./src/compiler/index.js",
         "./decorators": "./src/runtime/decorators.js",
         "./globals": "./src/types/globals.d.ts",
-        "./eslint-globals": "./src/types/eslint-globals.js"
+        "./eslint-globals": "./src/types/eslint-globals.js",
+        "./src/*": "./src/*"
     },
     "bin": {
         "yon.init": "./bin/yon.init.js",

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -1915,16 +1915,28 @@ export default class extends Tac {
         const packages = await packageFile.json();
         const modules = Object.keys(packages.dependencies ?? {});
         for (const mod of modules) {
+            // Scoped packages use a + separator in route paths so the /
+            // in @scope/name is not treated as a path segment delimiter.
+            const routeKey = mod.replace('/', '+');
+            // Resolve to a file path so Bun.build handles scoped packages
+            // without trying to open @scope as a root directory.
+            let entry = mod;
+            try {
+                const resolved = Bun.resolveSync(mod, process.cwd());
+                if (resolved && resolved !== mod)
+                    entry = resolved;
+            }
+            catch {
+                // Fall through — Bun.build may still resolve the bare specifier
+            }
             try {
                 const result = await Bun.build({
-                    // Let Bun resolve package exports/main/module fields instead
-                    // of manually guessing node_modules entry files.
-                    entrypoints: [mod],
+                    entrypoints: [entry],
                     minify: true
                 });
                 for (const output of result.outputs) {
-                    Router.reqRoutes[`/modules/${mod}.js`] = {
-                        GET: () => jsResponse(`/modules/${mod}.js`, output)
+                    Router.reqRoutes[`/modules/${routeKey}.js`] = {
+                        GET: () => jsResponse(`/modules/${routeKey}.js`, output)
                     };
                 }
             }

--- a/src/server/yon.js
+++ b/src/server/yon.js
@@ -956,7 +956,18 @@ export default class Yon {
                     else if (method === "OPTIONS") {
                         requestKind = 'options';
                         const routePath = route === '/' ? '' : Router.routeToFilesystemPath(route);
-                        res = new Response(Bun.file(`${Router.routesPath}${routePath}/${Router.optionsFileName}`), { status: 200, headers: { ...Router.getHeaders(request), 'Content-Type': 'application/json' } });
+                        responseHeaders = Router.getHeaders(request);
+                        const isPreflight = request.headers.get('origin') && request.headers.get('Access-Control-Request-Method');
+                        if (isPreflight) {
+                            res = new Response(null, { status: 204, headers: responseHeaders });
+                        }
+                        else if ((process.env.YON_BASIC_AUTH || process.env.YON_BASIC_AUTH_HASH)
+                            && !await Yon.isAuthorizedClient(request.headers.get('authorization'), process.env.YON_BASIC_AUTH, process.env.YON_BASIC_AUTH_HASH)) {
+                            res = Response.json({ detail: "Unauthorized Client" }, { status: 401, headers: { ...responseHeaders, "WWW-Authenticate": 'Basic realm="Secure Area"' } });
+                        }
+                        else {
+                            res = new Response(Bun.file(`${Router.routesPath}${routePath}/${Router.optionsFileName}`), { status: 200, headers: { ...responseHeaders, 'Content-Type': 'application/json' } });
+                        }
                     }
                     else {
                         if (Router.middleware?.before) {

--- a/tests/integration/api-routes.test.js
+++ b/tests/integration/api-routes.test.js
@@ -485,8 +485,13 @@ describe('Request body parsing', () => {
 // OPTIONS Route
 // ===========================================================================
 describe('OPTIONS route', () => {
-    test('OPTIONS /languages/typescript/items returns schema JSON', async () => {
+    test('unauthenticated direct OPTIONS returns 401', async () => {
         const res = await fetch(`${BASE_URL}/languages/typescript/items`, { method: 'OPTIONS' });
+        expect(res.status).toEqual(401);
+    });
+
+    test('authenticated direct OPTIONS returns schema JSON', async () => {
+        const res = await authFetch('/languages/typescript/items', { method: 'OPTIONS' });
         expect(res.status).toEqual(200);
         expect(res.headers.get('content-type')).toContain('application/json');
         const body = await res.json();
@@ -494,30 +499,34 @@ describe('OPTIONS route', () => {
         expect(body).toHaveProperty('POST');
         expect(body).toHaveProperty('DELETE');
     });
-    test('OPTIONS /languages/javascript returns schema JSON', async () => {
-        const res = await fetch(`${BASE_URL}/languages/javascript`, { method: 'OPTIONS' });
+
+    test('authenticated OPTIONS /languages/javascript returns schema JSON', async () => {
+        const res = await authFetch('/languages/javascript', { method: 'OPTIONS' });
         expect(res.status).toEqual(200);
         const body = await res.json();
         expect(body).toHaveProperty('GET');
         expect(body).toHaveProperty('POST');
         expect(body).toHaveProperty('PUT');
     });
-    test('OPTIONS /languages/python/versions/:version returns schema JSON', async () => {
-        const res = await fetch(`${BASE_URL}/languages/python/versions/v2`, { method: 'OPTIONS' });
+
+    test('authenticated OPTIONS /languages/python/versions/:version returns schema JSON', async () => {
+        const res = await authFetch('/languages/python/versions/v2', { method: 'OPTIONS' });
         expect(res.status).toEqual(200);
         const body = await res.json();
         expect(body).toHaveProperty('GET');
         expect(body).toHaveProperty('DELETE');
         expect(body).toHaveProperty('PATCH');
     });
+
     test('OPTIONS schema has numeric status code keys', async () => {
-        const res = await fetch(`${BASE_URL}/languages/javascript`, { method: 'OPTIONS' });
+        const res = await authFetch('/languages/javascript', { method: 'OPTIONS' });
         const body = await res.json();
         expect(body.GET).toHaveProperty('200');
         expect(body.GET).toHaveProperty('500');
         expect(body.GET['200']).toHaveProperty('message');
     });
-    test('OPTIONS preflight response includes configured CORS headers', async () => {
+
+    test('OPTIONS preflight (CORS) returns 204 with headers, no schema body', async () => {
         const res = await fetch(`${BASE_URL}/languages/javascript`, {
             method: 'OPTIONS',
             headers: {
@@ -526,7 +535,8 @@ describe('OPTIONS route', () => {
                 'Access-Control-Request-Headers': 'Content-Type,Authorization',
             },
         });
-        expect(res.status).toEqual(200);
+        expect(res.status).toEqual(204);
+        expect(await res.text()).toBe('');
         expect(res.headers.get('access-control-allow-origin')).toBe('https://app.example.com');
         expect(res.headers.get('access-control-allow-methods')).toBe('GET,POST,PUT,DELETE,PATCH,OPTIONS');
         expect(res.headers.get('access-control-allow-headers')).toBe('Content-Type,Authorization');


### PR DESCRIPTION
## Summary
- **Fix #64**: `bundleDependencies` encodes scoped packages with `+` separator in route paths and resolves entrypoints via `Bun.resolveSync` to prevent "failed to open root directory: @scope" errors
- **Fix #63**: Added `"./src/*"` to package.json exports map — eliminates `sed` workarounds in serverless/Lambda builds
- **OPTIONS auth**: CORS preflight returns 204 with headers only; direct OPTIONS requests require basic auth when configured
- All existing tests pass (264 tests, 0 failures)

## Test plan
- [x] Full test suite: 264 pass, 0 fail
- [x] Examples build succeeds with new exports map
- [x] OPTIONS tests: unauthenticated rejected (401), authenticated returns schema (200), preflight returns 204

🤖 Generated with [Claude Code](https://claude.com/claude-code)