### PR TITLE
Prepare Tachyon 26.28.04 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,9 +231,9 @@ bun -e "console.log(await Bun.password.hash('user:pass'))"
 <details>
 <summary><h2 style="display:inline">FYLO Storage</h2></summary>
 
-Tachyon uses `@d31ma/fylo@26.25.1`, which is filesystem-first and uses the
-FYLO `local-fs` index backend by default. Set `FYLO_ROOT` to the directory that
-should contain FYLO-managed collections:
+Tachyon drives the FYLO GitHub release binary through its vendored runtime shim.
+FYLO is filesystem-first and uses the `local-fs` index backend by default. Set
+`FYLO_ROOT` to the directory that should contain FYLO-managed collections:
 
 ```env
 FYLO_ROOT=db
@@ -1328,10 +1328,10 @@ Inside Tac page/component scripts only, `fetch()` is wrapped with a local-first 
 
 This does not override the global browser `fetch` outside Tac page/component execution.
 
-The compiler-injected `fylo` browser client is backed by
-`@d31ma/fylo/browser`. FYLO stores browser-local documents in OPFS when the
-browser supports it, falls back to memory when OPFS is unavailable, and prefers
-a `SharedWorker`/`Worker` boundary so reads, writes, query filtering, and
+The compiler-injected `fylo` browser client is backed by Tachyon's vendored FYLO
+browser shim. FYLO stores browser-local documents in OPFS when the browser
+supports it, falls back to memory when OPFS is unavailable, and prefers a
+`SharedWorker`/`Worker` boundary so reads, writes, query filtering, and
 collection events stay off the UI thread. Tachyon keeps the older IndexedDB
 response cache as the network fallback layer for plain `fetch()` calls.
 

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,16 +1,16 @@
 # Graph Report - TACHYON  (2026-07-09)
 
 ## Corpus Check
-- 183 files · ~203,063 words
+- 183 files · ~203,079 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 6332 nodes · 12332 edges · 314 communities (211 shown, 103 thin omitted)
+- 6332 nodes · 12332 edges · 312 communities (214 shown, 98 thin omitted)
 - Extraction: 93% EXTRACTED · 7% INFERRED · 0% AMBIGUOUS · INFERRED: 867 edges (avg confidence: 0.8)
 - Token cost: 0 input · 0 output
 
 ## Graph Freshness
-- Built from commit: `1b51410e`
+- Built from commit: `25205ab3`
 - Run `git rev-parse HEAD` and compare to check if the graph is stale.
 - Run `graphify update .` after code changes (no API cost).
 
@@ -121,6 +121,7 @@
 - [[_COMMUNITY_Community 103|Community 103]]
 - [[_COMMUNITY_Community 104|Community 104]]
 - [[_COMMUNITY_Community 105|Community 105]]
+- [[_COMMUNITY_Community 106|Community 106]]
 - [[_COMMUNITY_Community 107|Community 107]]
 - [[_COMMUNITY_Community 108|Community 108]]
 - [[_COMMUNITY_Community 109|Community 109]]
@@ -136,6 +137,7 @@
 - [[_COMMUNITY_Community 119|Community 119]]
 - [[_COMMUNITY_Community 120|Community 120]]
 - [[_COMMUNITY_Community 121|Community 121]]
+- [[_COMMUNITY_Community 122|Community 122]]
 - [[_COMMUNITY_Community 123|Community 123]]
 - [[_COMMUNITY_Community 124|Community 124]]
 - [[_COMMUNITY_Community 125|Community 125]]
@@ -160,7 +162,6 @@
 - [[_COMMUNITY_Community 144|Community 144]]
 - [[_COMMUNITY_Community 145|Community 145]]
 - [[_COMMUNITY_Community 146|Community 146]]
-- [[_COMMUNITY_Community 147|Community 147]]
 - [[_COMMUNITY_Community 148|Community 148]]
 - [[_COMMUNITY_Community 149|Community 149]]
 - [[_COMMUNITY_Community 150|Community 150]]
@@ -179,14 +180,13 @@
 - [[_COMMUNITY_Community 163|Community 163]]
 - [[_COMMUNITY_Community 164|Community 164]]
 - [[_COMMUNITY_Community 165|Community 165]]
-- [[_COMMUNITY_Community 167|Community 167]]
+- [[_COMMUNITY_Community 166|Community 166]]
 - [[_COMMUNITY_Community 168|Community 168]]
 - [[_COMMUNITY_Community 169|Community 169]]
 - [[_COMMUNITY_Community 170|Community 170]]
 - [[_COMMUNITY_Community 171|Community 171]]
 - [[_COMMUNITY_Community 172|Community 172]]
-- [[_COMMUNITY_Community 174|Community 174]]
-- [[_COMMUNITY_Community 175|Community 175]]
+- [[_COMMUNITY_Community 173|Community 173]]
 - [[_COMMUNITY_Community 176|Community 176]]
 - [[_COMMUNITY_Community 177|Community 177]]
 - [[_COMMUNITY_Community 178|Community 178]]
@@ -197,7 +197,6 @@
 - [[_COMMUNITY_Community 183|Community 183]]
 - [[_COMMUNITY_Community 184|Community 184]]
 - [[_COMMUNITY_Community 185|Community 185]]
-- [[_COMMUNITY_Community 186|Community 186]]
 - [[_COMMUNITY_Community 187|Community 187]]
 - [[_COMMUNITY_Community 188|Community 188]]
 - [[_COMMUNITY_Community 189|Community 189]]
@@ -207,7 +206,6 @@
 - [[_COMMUNITY_Community 193|Community 193]]
 - [[_COMMUNITY_Community 194|Community 194]]
 - [[_COMMUNITY_Community 195|Community 195]]
-- [[_COMMUNITY_Community 196|Community 196]]
 - [[_COMMUNITY_Community 197|Community 197]]
 - [[_COMMUNITY_Community 198|Community 198]]
 - [[_COMMUNITY_Community 199|Community 199]]
@@ -233,6 +231,8 @@
 - [[_COMMUNITY_Community 219|Community 219]]
 - [[_COMMUNITY_Community 220|Community 220]]
 - [[_COMMUNITY_Community 221|Community 221]]
+- [[_COMMUNITY_Community 222|Community 222]]
+- [[_COMMUNITY_Community 223|Community 223]]
 - [[_COMMUNITY_Community 224|Community 224]]
 - [[_COMMUNITY_Community 225|Community 225]]
 - [[_COMMUNITY_Community 226|Community 226]]
@@ -256,9 +256,9 @@
 - [[_COMMUNITY_Community 246|Community 246]]
 - [[_COMMUNITY_Community 247|Community 247]]
 - [[_COMMUNITY_Community 248|Community 248]]
-- [[_COMMUNITY_Community 249|Community 249]]
 - [[_COMMUNITY_Community 250|Community 250]]
 - [[_COMMUNITY_Community 251|Community 251]]
+- [[_COMMUNITY_Community 252|Community 252]]
 - [[_COMMUNITY_Community 253|Community 253]]
 - [[_COMMUNITY_Community 254|Community 254]]
 - [[_COMMUNITY_Community 255|Community 255]]
@@ -266,7 +266,6 @@
 - [[_COMMUNITY_Community 257|Community 257]]
 - [[_COMMUNITY_Community 258|Community 258]]
 - [[_COMMUNITY_Community 259|Community 259]]
-- [[_COMMUNITY_Community 260|Community 260]]
 - [[_COMMUNITY_Community 261|Community 261]]
 - [[_COMMUNITY_Community 262|Community 262]]
 - [[_COMMUNITY_Community 263|Community 263]]
@@ -289,19 +288,17 @@
 - [[_COMMUNITY_Community 280|Community 280]]
 - [[_COMMUNITY_Community 281|Community 281]]
 - [[_COMMUNITY_Community 282|Community 282]]
-- [[_COMMUNITY_Community 283|Community 283]]
 - [[_COMMUNITY_Community 284|Community 284]]
 - [[_COMMUNITY_Community 285|Community 285]]
 - [[_COMMUNITY_Community 287|Community 287]]
 - [[_COMMUNITY_Community 288|Community 288]]
+- [[_COMMUNITY_Community 289|Community 289]]
 - [[_COMMUNITY_Community 290|Community 290]]
-- [[_COMMUNITY_Community 291|Community 291]]
-- [[_COMMUNITY_Community 292|Community 292]]
+- [[_COMMUNITY_Community 307|Community 307]]
+- [[_COMMUNITY_Community 308|Community 308]]
 - [[_COMMUNITY_Community 309|Community 309]]
 - [[_COMMUNITY_Community 310|Community 310]]
 - [[_COMMUNITY_Community 311|Community 311]]
-- [[_COMMUNITY_Community 312|Community 312]]
-- [[_COMMUNITY_Community 313|Community 313]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `Compiler` - 148 edges
@@ -335,7 +332,7 @@
 - **Dashboard Page Composition** — index_dashboard_page, index_stats_grid, index_panel_helpers, index_wasm_zig_clicker, index_wasm_go_clicker, index_wasm_clicker, index_wasm_assemblyscript_clicker, index_wasm_rust_clicker, index_wasm_c_clicker [INFERRED]
 - **FYLO Database Ecosystem** — readme_db_structure, readme_fylo_system, readme_chex_schemas, readme_versioned_schema_layout, readme_seed_data, app_app_shell, index_stats_grid [INFERRED]
 
-## Communities (314 total, 103 thin omitted)
+## Communities (312 total, 98 thin omitted)
 
 ### Community 0 - "Community 0"
 Cohesion: 0.02
@@ -378,16 +375,16 @@ Cohesion: 0.05
 Nodes (48): main(), run(), startServer(), shutdown(), main(), results, run(), startServer() (+40 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.05
-Nodes (5): runSelectiveBuild(), writeRouteOutput(), Compiler, buildFingerprint(), pathFingerprint()
+Cohesion: 0.06
+Nodes (3): runSelectiveBuild(), writeRouteOutput(), Compiler
 
 ### Community 11 - "Community 11"
-Cohesion: 0.09
-Nodes (49): assertEditableDocument(), BROWSER_PATH, browserContentSecurityPolicy(), clampEventStreamPollMs(), createRestDocument(), delegateToOfficialHandler(), deleteDocument(), deleteRestDocument() (+41 more)
+Cohesion: 0.05
+Nodes (38): applyTheme(), bindPersistentFields(), bindReactiveFields(), bindThemeListener(), browserEnv, constructor(), fylo, get() (+30 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.06
-Nodes (40): basename(), BrowserPrefixIndexCodec, bytesToHex(), CollectionNotFoundError, createBrowserFylo(), createOpfsFilesystem(), createWorkerClient(), decodeSegment() (+32 more)
+Cohesion: 0.09
+Nodes (48): assertEditableDocument(), BROWSER_PATH, browserContentSecurityPolicy(), clampEventStreamPollMs(), createRestDocument(), delegateToOfficialHandler(), deleteDocument(), deleteRestDocument() (+40 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.04
@@ -395,79 +392,79 @@ Nodes (48): authFetch(), authHeaders(), decodeAnyValue(), describeEarlyExit(), e
 
 ### Community 14 - "Community 14"
 Cohesion: 0.05
-Nodes (35): applyTheme(), bindPersistentFields(), bindReactiveFields(), bindThemeListener(), browserEnv, constructor(), fylo, get() (+27 more)
-
-### Community 15 - "Community 15"
-Cohesion: 0.08
-Nodes (43): assertEditableDocument(), browserContentSecurityPolicy(), createRestDocument(), deleteDocument(), deleteRestDocument(), BROWSER_PATH, browserContentSecurityPolicy(), browserLogger (+35 more)
-
-### Community 16 - "Community 16"
-Cohesion: 0.05
 Nodes (34): bindPersistentFields(), bindReactiveFields(), bindRefreshListeners(), browserEnv, fylo, get(), getOwnPropertyDescriptor(), has() (+26 more)
 
-### Community 17 - "Community 17"
+### Community 15 - "Community 15"
+Cohesion: 0.09
+Nodes (42): assertEditableDocument(), browserContentSecurityPolicy(), createRestDocument(), deleteDocument(), deleteRestDocument(), BROWSER_PATH, browserContentSecurityPolicy(), browserLogger (+34 more)
+
+### Community 16 - "Community 16"
 Cohesion: 0.04
 Nodes (54): [26.22.03] — 2026-05-27, Added, Added, Added, Added, Added, Added, Added (+46 more)
 
-### Community 18 - "Community 18"
+### Community 17 - "Community 17"
 Cohesion: 0.04
 Nodes (29): bindPersistentFields(), bindReactiveFields(), bindRefreshListener(), browserEnv, DiagnosticsPayload, fylo, get(), getOwnPropertyDescriptor() (+21 more)
 
-### Community 19 - "Community 19"
-Cohesion: 0.07
-Nodes (48): classifyChange(), loadPostBundleHook(), normalizeRelative(), pathExists(), runBuild(), runPostBundleHook(), runWithConcurrency(), startBundleWatcher() (+40 more)
-
-### Community 20 - "Community 20"
+### Community 18 - "Community 18"
 Cohesion: 0.05
 Nodes (30): addItem(), bindPersistentFields(), bindReactiveFields(), bindRefreshListener(), browserEnv, clearItems(), formatDate(), fylo (+22 more)
 
-### Community 21 - "Community 21"
-Cohesion: 0.07
-Nodes (13): appendGroup(), BrowserCollectionFacade, browserProtocolError(), collectDeletedDocs(), collectFindDocs(), executeBrowserOperation(), FyloBrowser, isBrowserRequest() (+5 more)
+### Community 19 - "Community 19"
+Cohesion: 0.12
+Nodes (7): assertPathInside(), BrowserCore, BrowserDocuments, clone(), decodeTime(), stripInternalFields(), validateDocId()
 
-### Community 22 - "Community 22"
+### Community 20 - "Community 20"
 Cohesion: 0.05
 Nodes (26): bindPersistentFields(), bindReactiveFields(), browserEnv, clearDraft(), fylo, get(), getOwnPropertyDescriptor(), has() (+18 more)
 
-### Community 23 - "Community 23"
-Cohesion: 0.07
-Nodes (29): imports, CASES, request, jsResponse(), staticRouteResponse(), typedResponse(), source, jsResponse() (+21 more)
-
-### Community 24 - "Community 24"
+### Community 21 - "Community 21"
 Cohesion: 0.06
 Nodes (32): bindPersistentFields(), bindReactiveFields(), browserEnv, chooseMood(), fylo, get(), getOwnPropertyDescriptor(), has() (+24 more)
 
-### Community 25 - "Community 25"
+### Community 22 - "Community 22"
 Cohesion: 0.05
 Nodes (31): bindPersistentFields(), bindReactiveFields(), bindRefreshListener(), browserEnv, formatResult(), fylo, get(), getOwnPropertyDescriptor() (+23 more)
 
-### Community 26 - "Community 26"
-Cohesion: 0.09
-Nodes (46): bin, bindPersistentFields(), bindReactiveFields(), browserEnv, bytes, constructor(), emit(), env() (+38 more)
+### Community 23 - "Community 23"
+Cohesion: 0.08
+Nodes (13): appendGroup(), BrowserCollectionFacade, browserProtocolError(), collectDeletedDocs(), collectFindDocs(), executeBrowserOperation(), FyloBrowser, isBrowserRequest() (+5 more)
 
-### Community 27 - "Community 27"
+### Community 24 - "Community 24"
 Cohesion: 0.05
 Nodes (28): bindPersistentFields(), bindReactiveFields(), bindRefreshListener(), browserEnv, fylo, get(), getOwnPropertyDescriptor(), has() (+20 more)
 
+### Community 25 - "Community 25"
+Cohesion: 0.08
+Nodes (45): bin, bindPersistentFields(), bindReactiveFields(), browserEnv, bytes, constructor(), emit(), env() (+37 more)
+
+### Community 26 - "Community 26"
+Cohesion: 0.07
+Nodes (44): classifyChange(), loadPostBundleHook(), normalizeRelative(), pathExists(), runBuild(), runPostBundleHook(), runWithConcurrency(), startBundleWatcher() (+36 more)
+
+### Community 28 - "Community 28"
+Cohesion: 0.06
+Nodes (27): bin, bindPersistentFields(), bindReactiveFields(), browserEnv, bytes, fylo, get(), getOwnPropertyDescriptor() (+19 more)
+
 ### Community 29 - "Community 29"
-Cohesion: 0.05
-Nodes (29): bindRefreshListener(), onMount2(), bindPersistentFields(), bindReactiveFields(), bindRefreshListener(), browserEnv, fylo, get() (+21 more)
+Cohesion: 0.06
+Nodes (34): basename(), bytesToHex(), CollectionNotFoundError, createBrowserFylo(), createOpfsFilesystem(), createWorkerClient(), decodeSegment(), docIdFromKey() (+26 more)
 
 ### Community 30 - "Community 30"
+Cohesion: 0.05
+Nodes (30): withCamelAliases(), ty_camelCasePropName(), get(), inject(), inject2(), isServer(), withCamelAliases(), bindPersistentFields() (+22 more)
+
+### Community 31 - "Community 31"
+Cohesion: 0.05
+Nodes (29): bindRefreshListener(), scheduleRerender(), bindPersistentFields(), bindReactiveFields(), bindRefreshListener(), browserEnv, fylo, get() (+21 more)
+
+### Community 32 - "Community 32"
 Cohesion: 0.04
 Nodes (45): [26.21.7] — 2026-05-24, Added, Added, Added, Added, Added, Added, Added (+37 more)
 
-### Community 31 - "Community 31"
-Cohesion: 0.06
-Nodes (31): constructor(), emit(), rerender(), __tac_apply_state__(), bin, bindPersistentFields(), bindReactiveFields(), browserEnv (+23 more)
-
-### Community 32 - "Community 32"
-Cohesion: 0.07
-Nodes (41): findEventTarget(), resolveHandler(), canHandleClientNavigation(), componentRegistry, currentNavigationTarget(), deferredDelegation, delegatedEvents, detectBrowserOS() (+33 more)
-
 ### Community 34 - "Community 34"
 Cohesion: 0.06
-Nodes (26): get(), inject(), inject2(), [name](), bindPersistentFields(), bindReactiveFields(), browserEnv, fylo (+18 more)
+Nodes (30): bin, bindPersistentFields(), bindReactiveFields(), browserEnv, bytes, emit(), fylo, GET() (+22 more)
 
 ### Community 35 - "Community 35"
 Cohesion: 0.08
@@ -475,39 +472,39 @@ Nodes (14): Handler, YonRequest, Handler, YonRequest, ItemRecord, JsonItemReposi
 
 ### Community 36 - "Community 36"
 Cohesion: 0.07
-Nodes (35): buildFyloBrowserPaths(), buildOperation(), buildSpec(), describeStatus(), docsContentSecurityPolicy(), docsScript(), docsStyles(), getDocsAssets() (+27 more)
+Nodes (40): findEventTarget(), canHandleClientNavigation(), componentRegistry, currentNavigationTarget(), deferredDelegation, delegatedEvents, detectBrowserOS(), dispatchAction() (+32 more)
 
 ### Community 37 - "Community 37"
+Cohesion: 0.07
+Nodes (35): buildFyloBrowserPaths(), buildOperation(), buildSpec(), describeStatus(), docsContentSecurityPolicy(), docsScript(), docsStyles(), getDocsAssets() (+27 more)
+
+### Community 38 - "Community 38"
 Cohesion: 0.05
 Nodes (18): get(), inject(), provide(), set(), browserEnv, fylo, get(), inject() (+10 more)
 
-### Community 38 - "Community 38"
-Cohesion: 0.15
-Nodes (10): assertPathInside(), BrowserDocuments, decodeTime(), dirname(), isNotFound(), listBucketedDocIds(), OpfsFilesystem, stripInternalFields() (+2 more)
-
 ### Community 39 - "Community 39"
-Cohesion: 0.06
-Nodes (28): bin, bindPersistentFields(), bindReactiveFields(), browserEnv, bytes, emit(), fylo, GET() (+20 more)
+Cohesion: 0.11
+Nodes (24): reduceToArtifacts(), removeTempDir(), removeWithRetry(), copyDirectory(), fsError(), link(), makeStats(), open() (+16 more)
 
-### Community 40 - "Community 40"
+### Community 41 - "Community 41"
 Cohesion: 0.06
-Nodes (28): bin, bindPersistentFields(), bindReactiveFields(), browserEnv, bytes, emit(), fylo, get() (+20 more)
+Nodes (28): isBrowser(), bin, bindPersistentFields(), bindReactiveFields(), browserEnv, bytes, emit(), fylo (+20 more)
 
 ### Community 42 - "Community 42"
 Cohesion: 0.06
-Nodes (35): createAppScaffold(), ensureEmptyDirectory(), defaultAppName(), initLogger, resolveAppName(), { targetArg, appName: providedAppName }, targetDir, appDir (+27 more)
+Nodes (28): bin, bindPersistentFields(), bindReactiveFields(), browserEnv, bytes, emit(), fylo, get() (+20 more)
 
-### Community 43 - "Community 43"
+### Community 44 - "Community 44"
 Cohesion: 0.06
-Nodes (22): bindPersistentFields(), bindReactiveFields(), browserEnv, fylo, get(), getOwnPropertyDescriptor(), has(), inject() (+14 more)
+Nodes (27): bin, bindPersistentFields(), bindReactiveFields(), browserEnv, bytes, fylo, get(), getOwnPropertyDescriptor() (+19 more)
 
 ### Community 45 - "Community 45"
 Cohesion: 0.06
-Nodes (25): bin, bindPersistentFields(), bindReactiveFields(), browserEnv, bytes, fylo, get(), getOwnPropertyDescriptor() (+17 more)
+Nodes (35): createAppScaffold(), ensureEmptyDirectory(), defaultAppName(), initLogger, resolveAppName(), { targetArg, appName: providedAppName }, targetDir, appDir (+27 more)
 
 ### Community 46 - "Community 46"
-Cohesion: 0.06
-Nodes (24): bin, bindPersistentFields(), bindReactiveFields(), browserEnv, bytes, fylo, get(), getOwnPropertyDescriptor() (+16 more)
+Cohesion: 0.09
+Nodes (26): CASES, request, big, get, program, request, small, tokens (+18 more)
 
 ### Community 47 - "Community 47"
 Cohesion: 0.06
@@ -515,15 +512,15 @@ Nodes (37): [1.11.1] and earlier, [26.23.01] — 2026-06-01, [26.28.01] - 2026-0
 
 ### Community 48 - "Community 48"
 Cohesion: 0.06
-Nodes (23): bindPersistentFields(), bindReactiveFields(), browserEnv, fylo, get(), getOwnPropertyDescriptor(), has(), inject() (+15 more)
+Nodes (21): bindPersistentFields(), bindReactiveFields(), browserEnv, fylo, get(), getOwnPropertyDescriptor(), has(), inject() (+13 more)
 
 ### Community 49 - "Community 49"
-Cohesion: 0.13
-Nodes (19): copyDirectory(), fsError(), link(), makeStats(), open(), openSyncAccess(), OpfsDirectoryHandle, OpfsFileHandle (+11 more)
+Cohesion: 0.06
+Nodes (23): bindPersistentFields(), bindReactiveFields(), browserEnv, fylo, get(), getOwnPropertyDescriptor(), has(), inject() (+15 more)
 
 ### Community 50 - "Community 50"
 Cohesion: 0.1
-Nodes (29): assetRoot, distPath, main(), nativeLogger, outputRoot, rawTarget, resolveAppName(), target (+21 more)
+Nodes (30): buildFingerprint(), bundleCliPath, distPath, pathFingerprint(), previewLogger, readPreviewServerOptions(), readStringArg(), runFreshBundleBuild() (+22 more)
 
 ### Community 51 - "Community 51"
 Cohesion: 0.09
@@ -538,76 +535,80 @@ Cohesion: 0.06
 Nodes (32): expectInteractiveSurface(), expectNoBrowserErrors(), waitForDashboardReady(), browserErrorMap, browserErrors, drawer, exampleName, expectDuvayShells() (+24 more)
 
 ### Community 54 - "Community 54"
+Cohesion: 0.1
+Nodes (35): assertEditableDocument(), clampEventStreamPollMs(), createRestDocument(), deleteDocument(), deleteRestDocument(), FyloBrowser, fyloRoot(), getDocument() (+27 more)
+
+### Community 55 - "Community 55"
+Cohesion: 0.12
+Nodes (11): BrowserPrefixIndex, BrowserPrefixIndexCodec, completeLines(), encodeFieldPath(), includeKeyInRange(), intersect(), parseWalMutation(), readTextIfExists() (+3 more)
+
+### Community 56 - "Community 56"
 Cohesion: 0.11
 Nodes (27): appInfo(), authorizedNativeCapabilities(), createResponse(), dispatchBuiltInNativeCapability(), dispatchNativeCapability(), ensureNativeBridge(), fetch(), hasServerSideOsApis() (+19 more)
 
-### Community 55 - "Community 55"
+### Community 57 - "Community 57"
 Cohesion: 0.07
 Nodes (28): createFakeIndexedDB(), installWindow(), SwiftFyloRepository, authHeaders, calls, completed, createFakeIndexedDB(), eventOffsets (+20 more)
 
-### Community 56 - "Community 56"
-Cohesion: 0.12
-Nodes (32): assertEditableDocument(), createRestDocument(), deleteDocument(), deleteRestDocument(), FyloBrowser, fyloRoot(), getDocument(), getEncryptedFields() (+24 more)
-
 ### Community 58 - "Community 58"
+Cohesion: 0.11
+Nodes (7): jsonOk(), basename(), basename(), Router, configureRoutes(), isAssetRequest(), shouldTreatAsAsset()
+
+### Community 60 - "Community 60"
 Cohesion: 0.07
 Nodes (28): adapter, BINARY_LANGUAGES, buildDir, buildImportMap(), canBuildBinary(), commandAvailable(), companionPaths, copyDir() (+20 more)
 
-### Community 59 - "Community 59"
-Cohesion: 0.11
-Nodes (15): ADAPTER_DIR, basename(), HandlerAdapter, HTTP_METHODS, isExecutableFile(), methodsFromOptionsSchema(), ADAPTER_DIR, BUILT_IN_PROVIDERS (+7 more)
-
-### Community 60 - "Community 60"
+### Community 61 - "Community 61"
 Cohesion: 0.09
 Nodes (16): basename(), CLASS_STYLE_LANGUAGES, headersObject(), isDirectory(), isExecutableFile(), MiddlewareAdapter, middlewareLogger, objectOrNull() (+8 more)
 
 ### Community 62 - "Community 62"
+Cohesion: 0.11
+Nodes (15): ADAPTER_DIR, basename(), HandlerAdapter, HTTP_METHODS, isExecutableFile(), methodsFromOptionsSchema(), ADAPTER_DIR, BUILT_IN_PROVIDERS (+7 more)
+
+### Community 63 - "Community 63"
+Cohesion: 0.12
+Nodes (10): HANDLERS, host, HANDLERS, host, response, decoder, encoder, platformSnapshot() (+2 more)
+
+### Community 65 - "Community 65"
 Cohesion: 0.09
 Nodes (28): clearHandlerBackends(), handlerPaths(), registerHandlerBackends(), bundleWatchEnabled, configureRoutes(), detectAppShape(), directoryHasFiles(), distPath (+20 more)
 
-### Community 63 - "Community 63"
+### Community 66 - "Community 66"
 Cohesion: 0.18
 Nodes (8): program, request, compileKotlinWorker(), KEYWORDS, Parser, PUNCT1, PUNCT2, tokenize()
 
-### Community 64 - "Community 64"
+### Community 67 - "Community 67"
 Cohesion: 0.06
 Nodes (25): trackBrowserErrors(), browserErrorMap, browserErrors, docsOperation, draft, exampleName, EXAMPLES_DIR, FIXTURE_ITEMS (+17 more)
 
-### Community 65 - "Community 65"
-Cohesion: 0.12
-Nodes (24): backendByHandler, clearBackends(), hasInHouseBackend(), resolveBackend(), setBackend(), BUILD_DIR, buildArtifactPath(), cacheKey() (+16 more)
+### Community 68 - "Community 68"
+Cohesion: 0.1
+Nodes (8): PythonLanguageRepository, PythonLanguageService, PythonLanguageRepository, PythonLanguageService, DELETE(), GET(), PATCH(), __status_code()
 
-### Community 66 - "Community 66"
+### Community 69 - "Community 69"
 Cohesion: 0.09
 Nodes (29): appendEvents(), pollEvents(), setEventsStatus(), startEventsTail(), stopEventsTail(), appendEvents(), collectionLabel, collectionsRoot (+21 more)
 
-### Community 67 - "Community 67"
-Cohesion: 0.09
-Nodes (24): bytes, first, large, request, response, second, small, label (+16 more)
+### Community 70 - "Community 70"
+Cohesion: 0.08
+Nodes (14): imports, a, b, eventIds, hostIds, html, registered, jsResponse() (+6 more)
 
-### Community 68 - "Community 68"
+### Community 71 - "Community 71"
 Cohesion: 0.11
 Nodes (22): assertRun(), copyIfExists(), createTachyonApp(), run(), tachyonTarball(), uniqueName(), assertRun(), copyIfExists() (+14 more)
 
-### Community 69 - "Community 69"
-Cohesion: 0.11
-Nodes (22): applyPublish(), applySubscribe(), emit(), env(), inject(), isDecoratorContext(), isPlainOptions(), memberSignalName() (+14 more)
-
-### Community 70 - "Community 70"
-Cohesion: 0.11
-Nodes (8): PythonLanguageRepository, PythonLanguageService, PythonLanguageRepository, PythonLanguageService, DELETE(), GET(), PATCH(), __status_code()
-
-### Community 71 - "Community 71"
-Cohesion: 0.1
-Nodes (22): syncAttributes(), syncFormControlState(), createValueEventDetail(), isCustomElement(), isSameNode(), morphChildren(), morphLightDomSlots(), ownedSlots() (+14 more)
+### Community 72 - "Community 72"
+Cohesion: 0.13
+Nodes (24): backendByHandler, clearBackends(), hasInHouseBackend(), resolveBackend(), setBackend(), BUILD_DIR, buildArtifactPath(), cacheKey() (+16 more)
 
 ### Community 73 - "Community 73"
 Cohesion: 0.11
-Nodes (5): FyloTelemetryRepository, OtlpValueDecoder, TelemetryService, OtlpValueDecoder, Handler
+Nodes (22): applyPublish(), applySubscribe(), emit(), env(), inject(), isDecoratorContext(), isPlainOptions(), memberSignalName() (+14 more)
 
-### Community 75 - "Community 75"
-Cohesion: 0.12
-Nodes (5): FyloBrowserClient, FyloCollectionClient, meta(), provide(), set()
+### Community 74 - "Community 74"
+Cohesion: 0.09
+Nodes (22): syncAttributes(), syncFormControlState(), cleanBooleanAttrs(), createValueEventDetail(), isCustomElement(), isSameNode(), morphLightDomSlots(), ownedSlots() (+14 more)
 
 ### Community 76 - "Community 76"
 Cohesion: 0.12
@@ -615,151 +616,163 @@ Nodes (5): FyloBrowserClient, FyloCollectionClient, meta(), provide(), set()
 
 ### Community 77 - "Community 77"
 Cohesion: 0.12
-Nodes (3): jsonOk(), Router, configureRoutes()
+Nodes (5): FyloBrowserClient, FyloCollectionClient, meta(), provide(), set()
 
 ### Community 78 - "Community 78"
 Cohesion: 0.11
 Nodes (19): localFirstFetch(), __tc_compiled_factory__, __tc_defaultPlatform, __tc_deleteCachedResponse(), TC_INTERNAL_FIELDS, __tc_isBrowserEnv(), __tc_module_imports__, __tc_openFetchCache() (+11 more)
 
-### Community 82 - "Community 82"
-Cohesion: 0.19
-Nodes (4): BrowserPrefixIndex, completeLines(), parseWalMutation(), readTextIfExists()
+### Community 81 - "Community 81"
+Cohesion: 0.1
+Nodes (11): FACADE, RESERVED, safeSegment(), TopicLog, log, clientId, originalEnv, reader (+3 more)
+
+### Community 85 - "Community 85"
+Cohesion: 0.15
+Nodes (3): ItemService, JsonItemRepository, loadManifests()
 
 ### Community 86 - "Community 86"
 Cohesion: 0.11
 Nodes (9): bytes, module, encodeName(), f64Bytes(), SECTION, signedLEB(), VAL, vector() (+1 more)
 
 ### Community 87 - "Community 87"
+Cohesion: 0.1
+Nodes (21): big, get, program, put, request, requestBytes, response, small (+13 more)
+
+### Community 89 - "Community 89"
 Cohesion: 0.09
 Nodes (11): YonRubyRunner, calls, captured, ctx, method, r, request, seen (+3 more)
 
-### Community 88 - "Community 88"
+### Community 90 - "Community 90"
 Cohesion: 0.09
 Nodes (9): FakeFile, FakeFileHandle, FakeSyncAccessHandle, installFakeOpfs(), docs, fylo, root, __resetOpfsFs() (+1 more)
 
-### Community 89 - "Community 89"
-Cohesion: 0.11
-Nodes (20): big, get, program, put, request, requestBytes, response, small (+12 more)
-
-### Community 91 - "Community 91"
+### Community 92 - "Community 92"
 Cohesion: 0.16
 Nodes (24): tac_default(), tac_default2(), tac_default2(), __ty_compiled_factory__, ty_createHelpers(), tac_default2(), tac_default2(), tac_default2() (+16 more)
 
-### Community 93 - "Community 93"
+### Community 94 - "Community 94"
 Cohesion: 0.12
 Nodes (21): loadUsers(), loadWithPolicy(), policyNote(), recordCacheRun(), applyUsersResult(), bindRefreshListener(), CachePolicy, CacheRun (+13 more)
 
 ### Community 95 - "Community 95"
-Cohesion: 0.16
-Nodes (7): decode(), basename(), basename(), Pool, isAssetRequest(), shouldTreatAsAsset(), readUntil()
-
-### Community 96 - "Community 96"
 Cohesion: 0.13
 Nodes (5): FyloBrowser, CppFyloRepository, loadLazyComponent(), CppLanguageService, string
 
-### Community 97 - "Community 97"
-Cohesion: 0.11
-Nodes (9): CHEX, warm(), dir, setup(), Fixture, helpers, instance, props (+1 more)
+### Community 96 - "Community 96"
+Cohesion: 0.21
+Nodes (4): dirname(), isNotFound(), listBucketedDocIds(), OpfsFilesystem
 
-### Community 98 - "Community 98"
+### Community 99 - "Community 99"
 Cohesion: 0.23
 Nodes (19): outputRoot, tempDirs, androidSdkRoot(), commandAvailable(), findFileRecursive(), gradleExecutable(), hasNativePackager(), outputTail() (+11 more)
 
-### Community 100 - "Community 100"
+### Community 101 - "Community 101"
+Cohesion: 0.2
+Nodes (4): createMemoryFilesystem(), MemoryFilesystem, notDirectory(), notFound()
+
+### Community 102 - "Community 102"
+Cohesion: 0.09
+Nodes (10): FakeNativeWorker, FakePeerConnection, filePath, first, invoke(), nativeWorker, responsePromise, second (+2 more)
+
+### Community 103 - "Community 103"
 Cohesion: 0.16
 Nodes (19): b, j, k, q, x, f(), g(), jQ() (+11 more)
 
-### Community 101 - "Community 101"
+### Community 104 - "Community 104"
 Cohesion: 0.1
 Nodes (17): CONFIG_ROOTS, createTypecheckStage(), elapsed, exists(), includesExamples, includesWebsite, isCloudSyncedPath(), projectRoot (+9 more)
 
-### Community 102 - "Community 102"
-Cohesion: 0.19
-Nodes (3): ItemService, JsonItemRepository, loadManifests()
-
-### Community 104 - "Community 104"
-Cohesion: 0.2
-Nodes (20): escapeHtml(), hasSessionStorage(), loadDocs(), loadPersistedState(), persistState(), prettyJson(), renderAll(), renderAuthFields() (+12 more)
-
 ### Community 105 - "Community 105"
+Cohesion: 0.15
+Nodes (4): OtlpValueDecoder, TelemetryService, OtlpValueDecoder, Handler
+
+### Community 106 - "Community 106"
 Cohesion: 0.17
 Nodes (17): collectRoutes(), directoryExists(), loadRoutes(), pathExists(), resolvePreviewFile(), resolveRouteTemplate(), resolveStaticPreviewRoot(), routeToPortablePath() (+9 more)
+
+### Community 107 - "Community 107"
+Cohesion: 0.17
+Nodes (10): program, request, compilePythonWorker(), KEYWORDS, Parser, PUNCT1, PUNCT2, significantLines() (+2 more)
 
 ### Community 108 - "Community 108"
 Cohesion: 0.1
 Nodes (20): companionPath, compilerScriptPath, cppCompanionPath, cppTemplatePath, executable, jsCompanionPath, kotlinCompanionPath, kotlinTemplatePath (+12 more)
 
 ### Community 109 - "Community 109"
-Cohesion: 0.17
-Nodes (10): program, request, compilePythonWorker(), KEYWORDS, Parser, PUNCT1, PUNCT2, significantLines() (+2 more)
+Cohesion: 0.13
+Nodes (5): pathExists(), buildFingerprint(), pathFingerprint(), createTypecheckStage(), exists()
 
 ### Community 110 - "Community 110"
-Cohesion: 0.2
-Nodes (4): createMemoryFilesystem(), MemoryFilesystem, notDirectory(), notFound()
-
-### Community 111 - "Community 111"
-Cohesion: 0.14
-Nodes (3): pathExists(), createTypecheckStage(), exists()
-
-### Community 112 - "Community 112"
 Cohesion: 0.1
 Nodes (21): CLI Binary Rename (tach.* to tac.*/yon.*), OOP Companion Classes (export default class extends Tac), @d31ma/tachyon/decorators Package Export, Local-First fetch() with IndexedDB, Polyglot Backend Handlers, Rationale: Framework Split into Tac+Yon in v2.0, Stage 3 Decorator Forms (@inject, @provide, @env, @onMount, @emit), Tac Frontend Layer (Changelog) (+13 more)
 
-### Community 113 - "Community 113"
-Cohesion: 0.11
-Nodes (15): HANDLERS, host, HANDLERS, host, response, big, get, program (+7 more)
+### Community 111 - "Community 111"
+Cohesion: 0.22
+Nodes (19): escapeHtml(), hasSessionStorage(), loadDocs(), loadPersistedState(), persistState(), prettyJson(), renderAll(), renderAuthPanel() (+11 more)
 
-### Community 115 - "Community 115"
+### Community 112 - "Community 112"
+Cohesion: 0.14
+Nodes (7): CHEX, warm(), dir, setup(), headers, laterRequestId, request
+
+### Community 114 - "Community 114"
 Cohesion: 0.15
 Nodes (13): call(), load_module(), resolve_handler_class(), resolve_method(), run(), write(), YonPythonRunner, FyloMachineRepository (+5 more)
 
 ### Community 116 - "Community 116"
-Cohesion: 0.13
-Nodes (9): FACADE, RESERVED, log, clientId, originalEnv, reader, repository, tempDirs (+1 more)
-
-### Community 118 - "Community 118"
 Cohesion: 0.18
 Nodes (12): applyEvent(), connect(), prepare(), readEventStream(), refreshClients(), register(), send(), connect() (+4 more)
 
-### Community 119 - "Community 119"
+### Community 117 - "Community 117"
 Cohesion: 0.11
 Nodes (16): fyloApiGet(), fyloRequest(), text(), ascScores, controller, decoder, descScores, firstId (+8 more)
 
-### Community 124 - "Community 124"
+### Community 120 - "Community 120"
 Cohesion: 0.15
 Nodes (9): call(), init(), output, readClicks(), writeState(), call(), init(), readClicks() (+1 more)
 
-### Community 125 - "Community 125"
+### Community 121 - "Community 121"
 Cohesion: 0.18
 Nodes (17): applyEvent(), editsLastHour(), isStreaming(), prepare(), pruneEditTimestamps(), readEventStream(), recordEdit(), start() (+9 more)
 
-### Community 126 - "Community 126"
-Cohesion: 0.21
-Nodes (9): withCamelAliases(), ty_camelCasePropName(), has(), provide(), provide2(), set(), TacWasmJsonRuntime, withCamelAliases() (+1 more)
-
-### Community 127 - "Community 127"
-Cohesion: 0.11
-Nodes (18): withCamelAliases(), ty_camelCasePropName(), withCamelAliases(), withCamelAliases(), withCamelAliases(), withCamelAliases(), withCamelAliases(), withCamelAliases() (+10 more)
-
-### Community 128 - "Community 128"
+### Community 122 - "Community 122"
 Cohesion: 0.16
 Nodes (3): FyloBrowser, env(), loadLazyComponent()
 
-### Community 129 - "Community 129"
+### Community 123 - "Community 123"
+Cohesion: 0.2
+Nodes (3): decode(), Pool, readUntil()
+
+### Community 124 - "Community 124"
 Cohesion: 0.23
 Nodes (6): createBackendOnlyApp(), buildRouteOutput(), writeExecutableHandler(), buildTestFactory(), YonJsRunner, write()
 
-### Community 132 - "Community 132"
+### Community 125 - "Community 125"
+Cohesion: 0.21
+Nodes (9): envValue(), fyloS3Options(), FyloTelemetryRepository, envValue(), fyloCacheOptions(), fyloOptions(), fyloS3Options(), isTruthy() (+1 more)
+
+### Community 128 - "Community 128"
 Cohesion: 0.12
 Nodes (9): adapter, cmd, commands, handlerPath, main, proc, startedAt, support (+1 more)
 
-### Community 133 - "Community 133"
+### Community 129 - "Community 129"
 Cohesion: 0.18
 Nodes (14): outputPath, proc, response, sourcePath, commandAvailable(), compileNativeWorkerExecutable(), compileRustWorkerExecutable(), detectRustMethods() (+6 more)
 
-### Community 134 - "Community 134"
+### Community 131 - "Community 131"
+Cohesion: 0.18
+Nodes (14): label, analyzeMethod(), ARITHMETIC_OPS, BINARY_OPS, COMPARISON_OPS, emitBlockValue(), emitConditionValue(), emitExpr() (+6 more)
+
+### Community 132 - "Community 132"
 Cohesion: 0.12
 Nodes (3): broker, FakeDataChannel, FakePeerConnection
+
+### Community 133 - "Community 133"
+Cohesion: 0.12
+Nodes (17): ty_camelCasePropName(), withCamelAliases(), withCamelAliases(), withCamelAliases(), withCamelAliases(), withCamelAliases(), withCamelAliases(), withCamelAliases() (+9 more)
+
+### Community 134 - "Community 134"
+Cohesion: 0.13
+Nodes (3): Handler, Handler, LanguageRepository
 
 ### Community 135 - "Community 135"
 Cohesion: 0.2
@@ -769,89 +782,89 @@ Nodes (3): InlineFyloCollectionClient, renderRestResult(), runQuery()
 Cohesion: 0.12
 Nodes (4): PATCH(), Handler, Handler, Json
 
-### Community 138 - "Community 138"
+### Community 137 - "Community 137"
 Cohesion: 0.15
 Nodes (9): cached, flag(), generateProject(), measure(), measureScript, pageJs(), repoRoot, results (+1 more)
 
-### Community 139 - "Community 139"
+### Community 138 - "Community 138"
 Cohesion: 0.25
 Nodes (14): compileJavaScriptWorker(), compileTypeScriptWorker(), extractHandlerClassBody(), findMatchingBrace(), inferDeclarationType(), mapReturnType(), normalizeBody(), normalizeParam() (+6 more)
 
-### Community 140 - "Community 140"
+### Community 139 - "Community 139"
 Cohesion: 0.15
 Nodes (4): RubyFyloRepository, RubyFyloRepository, RubyLanguageService, RubyLanguageService
 
 ### Community 141 - "Community 141"
-Cohesion: 0.16
-Nodes (3): Handler, LanguageRepository, LanguageService
-
-### Community 142 - "Community 142"
 Cohesion: 0.13
 Nodes (7): bundle, bundleEntrypoint, createExampleApp(), preview, previewEntrypoint, processes, tempDirs
 
-### Community 147 - "Community 147"
-Cohesion: 0.13
-Nodes (9): FakePeerConnection, filePath, first, invoke(), nativeWorker, responsePromise, second, tempDirs (+1 more)
+### Community 143 - "Community 143"
+Cohesion: 0.28
+Nodes (14): morphChildren(), parseFragment(), findLazyAncestor(), isInsideSlot(), observeLazyComponents(), patchBody(), patchSlot(), postPatch() (+6 more)
 
-### Community 148 - "Community 148"
-Cohesion: 0.27
-Nodes (7): emit(), provide(), rerender(), set(), __tac_apply_state__(), TacWasmJsonRuntime, withCamelAliases()
+### Community 144 - "Community 144"
+Cohesion: 0.19
+Nodes (9): installConsoleLogger(), buildCurl(), buildExecution(), buildRequestPayload(), executeOperation(), findOperationMethod(), locateOperation(), operationSlug() (+1 more)
 
 ### Community 149 - "Community 149"
 Cohesion: 0.27
 Nodes (7): emit(), provide(), rerender(), set(), __tac_apply_state__(), TacWasmJsonRuntime, withCamelAliases()
 
+### Community 150 - "Community 150"
+Cohesion: 0.27
+Nodes (7): emit(), provide(), rerender(), set(), __tac_apply_state__(), TacWasmJsonRuntime, withCamelAliases()
+
 ### Community 151 - "Community 151"
+Cohesion: 0.17
+Nodes (5): PythonFyloRepository, GET(), Handler, __status_code(), PythonFyloRepository
+
+### Community 152 - "Community 152"
 Cohesion: 0.2
 Nodes (3): TelemetryAlertWorker, TelemetryAlertWorker, worker
 
-### Community 153 - "Community 153"
+### Community 156 - "Community 156"
 Cohesion: 0.18
 Nodes (4): JavaLanguageService, ty_createScope(), JavaFyloRepository, JavaLanguageService
 
-### Community 155 - "Community 155"
+### Community 158 - "Community 158"
 Cohesion: 0.25
 Nodes (14): render(), cleanBooleanAttrs(), isSameNode(), morphChildren(), parseFragment(), findLazyAncestor(), isInsideSlot(), observeLazyComponents() (+6 more)
 
-### Community 157 - "Community 157"
+### Community 159 - "Community 159"
 Cohesion: 0.21
 Nodes (13): encryptionBanner(), errorMessage(), loadCollections(), previewOf(), renderDetail(), renderError(), renderRestResult(), runQuery() (+5 more)
 
-### Community 158 - "Community 158"
-Cohesion: 0.23
-Nodes (13): installConsoleLogger(), buildCurl(), buildExecution(), buildRequestPayload(), defaultParameterValue(), defaultRequestBody(), ensureOperationState(), exampleFromSchema() (+5 more)
-
-### Community 159 - "Community 159"
+### Community 160 - "Community 160"
 Cohesion: 0.16
 Nodes (3): Handler, Handler, RealtimeService
 
-### Community 160 - "Community 160"
-Cohesion: 0.2
-Nodes (13): buildFingerprint(), bundleCliPath, distPath, pathFingerprint(), previewLogger, readPreviewServerOptions(), readStringArg(), runFreshBundleBuild() (+5 more)
-
 ### Community 161 - "Community 161"
-Cohesion: 0.28
-Nodes (13): cleanBooleanAttrs(), parseFragment(), findLazyAncestor(), isInsideSlot(), observeLazyComponents(), patchBody(), patchSlot(), postPatch() (+5 more)
+Cohesion: 0.23
+Nodes (4): expectInteractiveSurface(), expectNoBrowserErrors(), waitForDashboardReady(), PackageContractVerifier
 
 ### Community 162 - "Community 162"
 Cohesion: 0.22
 Nodes (12): encryptionBanner(), errorMessage(), loadCollections(), loadMeta(), previewOf(), renderDetail(), renderError(), selectCollection() (+4 more)
 
 ### Community 164 - "Community 164"
-Cohesion: 0.24
-Nodes (9): clearToolchainConfig(), defaultInterpreters(), defaultToolchainConfig(), describeToolchain(), loadToolchainConfig(), resolveCompiler(), resolveInterpreter(), config (+1 more)
-
-### Community 165 - "Community 165"
 Cohesion: 0.23
 Nodes (10): canRunPlaywright(), decode(), resolveNodeCommand(), runCommand(), canRunPlaywright(), decode(), output, resolveNodeCommand() (+2 more)
 
-### Community 167 - "Community 167"
-Cohesion: 0.19
-Nodes (3): resetTacWorkerPoolsForTest(), TacNativeWorkerClient, TacWorkerClient
+### Community 165 - "Community 165"
+Cohesion: 0.24
+Nodes (9): clearToolchainConfig(), defaultInterpreters(), defaultToolchainConfig(), describeToolchain(), loadToolchainConfig(), resolveCompiler(), resolveInterpreter(), config (+1 more)
+
+### Community 166 - "Community 166"
+Cohesion: 0.18
+Nodes (11): assetRoot, distPath, main(), nativeLogger, outputRoot, rawTarget, resolveAppName(), target (+3 more)
 
 ### Community 168 - "Community 168"
-Cohesion: 0.26
-Nodes (4): expectInteractiveSurface(), expectNoBrowserErrors(), waitForDashboardReady(), PackageContractVerifier
+Cohesion: 0.18
+Nodes (10): bytes, first, large, request, response, second, small, buildHandlerModule() (+2 more)
+
+### Community 169 - "Community 169"
+Cohesion: 0.19
+Nodes (3): resetTacWorkerPoolsForTest(), TacNativeWorkerClient, TacWorkerClient
 
 ### Community 170 - "Community 170"
 Cohesion: 0.24
@@ -865,67 +878,59 @@ Nodes (10): bundleEntrypoint, componentModule, createFixture(), decoder, docsInd
 Cohesion: 0.23
 Nodes (4): InlineFyloBrowserClient, loadMeta(), createFyloClient(), importFylo()
 
-### Community 174 - "Community 174"
-Cohesion: 0.18
-Nodes (10): code:text (db/), code:text (db/schemas/<collection>/), code:text (db/.collections/<collection>/docs/<prefix>/<document-id>.jso), code:bash (fylo.admin rebuild <collection> --root db), .collections/, db/, Layout, .queue/ (+2 more)
-
-### Community 175 - "Community 175"
-Cohesion: 0.27
-Nodes (9): createPublicBrowserEnvResponse(), createPublicBrowserEnvScript(), getPublicBrowserEnv(), splitList(), createPublicBrowserEnvResponse(), createPublicBrowserEnvScript(), getPublicBrowserEnv(), splitList() (+1 more)
+### Community 173 - "Community 173"
+Cohesion: 0.26
+Nodes (11): withPublicBrowserEnv(), applySecurity(), defaultParameterValue(), defaultRequestBody(), ensureOperationState(), exampleFromSchema(), renderAuthFields(), renderSecurityBadges() (+3 more)
 
 ### Community 176 - "Community 176"
 Cohesion: 0.18
+Nodes (10): code:text (db/), code:text (db/schemas/<collection>/), code:text (db/.collections/<collection>/docs/<prefix>/<document-id>.jso), code:bash (fylo.admin rebuild <collection> --root db), .collections/, db/, Layout, .queue/ (+2 more)
+
+### Community 177 - "Community 177"
+Cohesion: 0.27
+Nodes (9): createPublicBrowserEnvResponse(), createPublicBrowserEnvScript(), getPublicBrowserEnv(), splitList(), createPublicBrowserEnvResponse(), createPublicBrowserEnvScript(), getPublicBrowserEnv(), splitList() (+1 more)
+
+### Community 178 - "Community 178"
+Cohesion: 0.18
 Nodes (11): buildScriptPath, bundleEntrypoint, createFixture(), decode(), hostManifest, nativeEntrypoint, readPngAlpha(), runCli() (+3 more)
 
-### Community 179 - "Community 179"
-Cohesion: 0.27
-Nodes (9): listCollections(), envValue(), fyloOptions(), fyloS3Options(), envValue(), fyloCacheOptions(), fyloS3Options(), isTruthy() (+1 more)
-
-### Community 180 - "Community 180"
+### Community 181 - "Community 181"
 Cohesion: 0.2
 Nodes (8): createDeferredDelegation(), replayCaptured(), capture, d, event, registered, replayed, target
 
-### Community 181 - "Community 181"
+### Community 182 - "Community 182"
 Cohesion: 0.24
 Nodes (3): ServiceWorkerPolicy, strategy, url
 
-### Community 182 - "Community 182"
+### Community 184 - "Community 184"
 Cohesion: 0.18
 Nodes (5): createExampleApp(), env, proc, processes, tempDirs
 
-### Community 184 - "Community 184"
+### Community 187 - "Community 187"
 Cohesion: 0.22
 Nodes (8): createBrowserClient(), createFyloClient(), fylo, FYLO_BROWSER_PATH(), sharedFyloProxy(), client, col, result
 
-### Community 185 - "Community 185"
+### Community 188 - "Community 188"
 Cohesion: 0.27
 Nodes (5): tokenizeCommand(), basename(), Pool, poolLogger, tokenizeCommand()
 
-### Community 186 - "Community 186"
-Cohesion: 0.24
-Nodes (8): headers, laterRequestId, request, decodeTime(), generate(), isTTID(), timeNow(), TTID
-
-### Community 187 - "Community 187"
+### Community 189 - "Community 189"
 Cohesion: 0.27
 Nodes (6): copy_bytes(), read_clicks(), tachyon_call(), tachyon_init(), write_state(), write_uint()
 
-### Community 196 - "Community 196"
+### Community 198 - "Community 198"
 Cohesion: 0.27
 Nodes (7): program, request, compileSwiftWorker(), KEYWORDS, PUNCT1, PUNCT2, tokenize()
-
-### Community 197 - "Community 197"
-Cohesion: 0.2
-Nodes (6): a, b, eventIds, hostIds, html, registered
 
 ### Community 206 - "Community 206"
 Cohesion: 0.24
 Nodes (8): decode(), runBundle(), bundleEntrypoint, createFixture(), decode(), docsIndex, runBundle(), tempDirs
 
-### Community 208 - "Community 208"
+### Community 207 - "Community 207"
 Cohesion: 0.2
 Nodes (7): Collection, DocEntry, EventEntry, QueryResult, onMount(), noopHelpers, Tac
 
-### Community 212 - "Community 212"
+### Community 211 - "Community 211"
 Cohesion: 0.22
 Nodes (5): createDistFixture(), createDistFixtureWithoutRoot(), createDynamicDistFixture(), tempDirs, createStaticPreviewServer()
 
@@ -933,19 +938,19 @@ Nodes (5): createDistFixture(), createDistFixtureWithoutRoot(), createDynamicDis
 Cohesion: 0.25
 Nodes (8): bindPersistentFields(), bindReactiveFields(), getOwnPropertyDescriptor(), has(), readLocalValue(), readSessionValue(), resolvePersistScope(), prehydratePersistentText()
 
-### Community 218 - "Community 218"
+### Community 220 - "Community 220"
 Cohesion: 0.29
 Nodes (3): connectHMR(), hmrFrameRequestsReload(), parseHmrFrame()
 
-### Community 219 - "Community 219"
+### Community 221 - "Community 221"
 Cohesion: 0.29
 Nodes (8): findEventTarget(), resolveHandler(), canHandleClientNavigation(), dispatchAction(), handleDelegatedEvent(), navigate(), resolveLayout(), resolvePageHandler()
 
-### Community 220 - "Community 220"
+### Community 222 - "Community 222"
 Cohesion: 0.29
 Nodes (3): context, SwiftLanguageService, Handler
 
-### Community 221 - "Community 221"
+### Community 223 - "Community 223"
 Cohesion: 0.25
 Nodes (5): SPAN_KIND, STATUS_CODE, telemetryLogger, TelemetryStore, TelemetryStore
 
@@ -961,13 +966,21 @@ Nodes (7): code:block1 (bun run bench:build                          # default s
 Cohesion: 0.36
 Nodes (6): binaryArtifactPath(), BUILD_DIR, getResponse(), log, spawnBinary(), tryRegister()
 
-### Community 229 - "Community 229"
+### Community 227 - "Community 227"
+Cohesion: 0.25
+Nodes (5): Fixture, helpers, instance, props, Fixture
+
+### Community 230 - "Community 230"
 Cohesion: 0.29
 Nodes (5): cleared, loaded, picked, saved, teardowns
 
 ### Community 236 - "Community 236"
 Cohesion: 0.29
 Nodes (5): changed, distWeb, file, incStart, routePath
+
+### Community 237 - "Community 237"
+Cohesion: 0.43
+Nodes (5): decodeTime(), generate(), isTTID(), timeNow(), TTID
 
 ### Community 238 - "Community 238"
 Cohesion: 0.33
@@ -981,111 +994,103 @@ Nodes (7): bindPersistentFields(), bindReactiveFields(), getOwnPropertyDescripto
 Cohesion: 0.29
 Nodes (7): Browser Env Allowlisting (TAC_PUBLIC_ENV), Yon Backend Routing (server/routes), Tachyon Configuration System (YON_*, TAC_*, FYLO_* env vars), Browser Env Allowlisting (TAC_PUBLIC_ENV), MVC Backend Architecture (routes->services->repositories), Rationale: MVC Backend Dependency Direction, Rationale: No Secure Browser Secrets Boundary
 
-### Community 248 - "Community 248"
+### Community 247 - "Community 247"
 Cohesion: 0.4
 Nodes (3): createComponentRegistry(), found, reg
 
-### Community 251 - "Community 251"
-Cohesion: 0.53
-Nodes (5): withPublicBrowserEnv(), applySecurity(), renderSecurityBadges(), securitySchemeNames(), keys
-
-### Community 254 - "Community 254"
+### Community 250 - "Community 250"
 Cohesion: 0.33
 Nodes (5): appStyles, fonts, materialScript, tailwind, tailwindConfig
 
-### Community 256 - "Community 256"
+### Community 252 - "Community 252"
 Cohesion: 0.33
 Nodes (3): TypeScriptLanguageService, YonRequest, TypeScriptLanguageService
 
-### Community 257 - "Community 257"
+### Community 253 - "Community 253"
 Cohesion: 0.33
 Nodes (3): CSharpFyloRepository, CSharpLanguageService, CSharpLanguageService
 
-### Community 259 - "Community 259"
+### Community 255 - "Community 255"
 Cohesion: 0.53
 Nodes (4): DELETE(), GET(), Handler, PATCH()
 
-### Community 260 - "Community 260"
+### Community 256 - "Community 256"
 Cohesion: 0.53
 Nodes (6): localFirstFetch(), __ty_deleteCachedResponse(), __ty_isBrowserEnv(), __ty_openFetchCache(), __ty_readCachedResponse(), __ty_writeCachedResponse()
 
-### Community 261 - "Community 261"
+### Community 257 - "Community 257"
 Cohesion: 0.33
 Nodes (6): Automatic Prop-to-Field Binding, SessionStorage Persistence for $-prefixed Fields, Automatic Prop-to-Field Binding, Rationale: Prop Value Wins Over Field Default, Reactive Companion Fields, $-Prefixed Field SessionStorage Persistence
 
-### Community 262 - "Community 262"
+### Community 258 - "Community 258"
 Cohesion: 0.7
 Nodes (4): cacheModuleResponse(), getCachedModule(), openCache(), precacheModules()
 
-### Community 263 - "Community 263"
+### Community 259 - "Community 259"
 Cohesion: 0.4
 Nodes (3): COMMANDS, rest, userArgs
 
-### Community 264 - "Community 264"
+### Community 262 - "Community 262"
 Cohesion: 0.4
 Nodes (4): dart:convert, dart:io, DartFyloRepository, _machine
 
-### Community 267 - "Community 267"
+### Community 265 - "Community 265"
 Cohesion: 0.4
 Nodes (5): getAvailablePort(), applyEvent(), readEventStream(), start(), stop()
 
-### Community 268 - "Community 268"
-Cohesion: 0.7
-Nodes (3): GET(), Handler, __status_code()
-
-### Community 269 - "Community 269"
+### Community 266 - "Community 266"
 Cohesion: 0.4
 Nodes (5): FYLO-backed OpenTelemetry Storage, @d31ma/fylo@26.19.7, FYLO Storage Backend (@d31ma/fylo), OpenTelemetry Storage (FYLO-backed), Rationale: OpenTelemetry Spans Fail Open
 
-### Community 270 - "Community 270"
+### Community 267 - "Community 267"
 Cohesion: 0.5
 Nodes (5): CHEX Regex Schemas, Database Layer (db/), FYLO Database System, Seed Data Import, Versioned Schema Layout
 
-### Community 272 - "Community 272"
+### Community 269 - "Community 269"
 Cohesion: 0.5
 Nodes (3): dart_language_service.dart, Handler, _statusCode
 
-### Community 273 - "Community 273"
+### Community 270 - "Community 270"
 Cohesion: 0.5
 Nodes (3): dart_fylo_repository.dart, DartLanguageService, DartLanguageService
 
-### Community 275 - "Community 275"
+### Community 272 - "Community 272"
 Cohesion: 0.5
 Nodes (4): Rationale: Language Compilers Are Optional, Rationale: Wasm Adapter Encapsulates DOM Access, tac-wasm-json@1 ABI, Wasm Companions
 
-### Community 276 - "Community 276"
+### Community 273 - "Community 273"
 Cohesion: 0.5
 Nodes (4): Distributed Rate Limiting (Upstash Redis), Production Security Hardening, Distributed Rate Limiting (Upstash Redis), Security Features (Hashed Basic Auth, CSP, HSTS, JWT)
 
-### Community 282 - "Community 282"
+### Community 279 - "Community 279"
 Cohesion: 0.67
 Nodes (3): not_found_default(), ty_createHelpers(), tac_default()
 
-### Community 283 - "Community 283"
+### Community 280 - "Community 280"
 Cohesion: 0.67
 Nodes (3): CHANGELOG.md Document, Keep a Changelog Format, Semantic Versioning 2.0.0
 
-### Community 284 - "Community 284"
+### Community 281 - "Community 281"
 Cohesion: 0.67
 Nodes (3): Scoped Component CSS (@scope wrapper), Scoped Component CSS, Tac Template System
 
-### Community 285 - "Community 285"
+### Community 282 - "Community 282"
 Cohesion: 0.67
 Nodes (3): Build Manifests Moved to src/shared/manifests/, Rationale: Separate Generated Artifacts from Runtime Source, Source File Reorganization (src/server/ subdirectories)
 
 ## Knowledge Gaps
 - **1182 isolated node(s):** `allocatedTestPorts`, `routeTestCases`, `languageRoutes`, `machineOperations`, `requestSpan` (+1177 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **103 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **98 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `set()` connect `Community 126` to `Community 0`, `Community 128`, `Community 2`, `Community 8`, `Community 10`, `Community 14`, `Community 15`, `Community 16`, `Community 18`, `Community 20`, `Community 22`, `Community 151`, `Community 24`, `Community 25`, `Community 26`, `Community 27`, `Community 23`, `Community 29`, `Community 158`, `Community 31`, `Community 157`, `Community 34`, `Community 36`, `Community 39`, `Community 40`, `Community 43`, `Community 45`, `Community 46`, `Community 48`, `Community 52`, `Community 64`, `Community 77`, `Community 209`, `Community 85`, `Community 92`, `Community 94`, `Community 95`, `Community 102`, `Community 105`, `Community 111`, `Community 120`, `Community 251`?**
+- **Why does `set()` connect `Community 11` to `Community 0`, `Community 2`, `Community 8`, `Community 10`, `Community 14`, `Community 15`, `Community 144`, `Community 17`, `Community 18`, `Community 20`, `Community 21`, `Community 22`, `Community 24`, `Community 152`, `Community 25`, `Community 28`, `Community 30`, `Community 31`, `Community 159`, `Community 34`, `Community 37`, `Community 41`, `Community 42`, `Community 44`, `Community 173`, `Community 48`, `Community 49`, `Community 52`, `Community 58`, `Community 67`, `Community 68`, `Community 70`, `Community 210`, `Community 85`, `Community 88`, `Community 93`, `Community 97`, `Community 106`, `Community 118`, `Community 122`, `Community 123`?**
   _High betweenness centrality (0.211) - this node is a cross-community bridge._
-- **Why does `string` connect `Community 96` to `Community 2`, `Community 5`, `Community 135`, `Community 8`, `Community 137`, `Community 9`, `Community 13`, `Community 141`, `Community 19`, `Community 152`, `Community 25`, `Community 158`, `Community 159`, `Community 32`, `Community 33`, `Community 162`, `Community 163`, `Community 169`, `Community 41`, `Community 54`, `Community 55`, `Community 56`, `Community 195`, `Community 69`, `Community 199`, `Community 73`, `Community 74`, `Community 220`, `Community 93`, `Community 103`, `Community 104`, `Community 243`, `Community 118`, `Community 246`, `Community 122`, `Community 251`?**
+- **Why does `string` connect `Community 95` to `Community 2`, `Community 5`, `Community 135`, `Community 8`, `Community 9`, `Community 13`, `Community 144`, `Community 145`, `Community 22`, `Community 155`, `Community 160`, `Community 33`, `Community 162`, `Community 163`, `Community 36`, `Community 39`, `Community 43`, `Community 173`, `Community 174`, `Community 54`, `Community 56`, `Community 57`, `Community 197`, `Community 200`, `Community 73`, `Community 75`, `Community 217`, `Community 218`, `Community 94`, `Community 222`, `Community 98`, `Community 105`, `Community 111`, `Community 243`, `Community 116`, `Community 245`?**
   _High betweenness centrality (0.164) - this node is a cross-community bridge._
-- **Why does `staticRouteResponse()` connect `Community 23` to `Community 126`, `Community 95`?**
+- **Why does `staticRouteResponse()` connect `Community 70` to `Community 58`, `Community 11`?**
   _High betweenness centrality (0.067) - this node is a cross-community bridge._
 - **Are the 78 inferred relationships involving `string` (e.g. with `getAvailablePort()` and `normalizeTelemetryPath()`) actually correct?**
   _`string` has 78 INFERRED edges - model-reasoned connections that need verification._

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d31ma/tachyon",
-  "version": "26.28.02",
+  "version": "26.28.04",
   "description": "A polyglot, file-system-routed full-stack framework for Bun",
   "author": "Chidelma",
   "license": "MIT",

--- a/src/runtime/fylo-global.js
+++ b/src/runtime/fylo-global.js
@@ -1,15 +1,11 @@
 // @ts-check
 //
 // Fylo browser client entry point — re-exports from the sync engine which wraps
-// the official @d31ma/fylo/browser module with HTTP sync, IndexedDB caching, and
+// Tachyon's vendored FYLO browser shim with HTTP sync, IndexedDB caching, and
 // SSE subscriptions.
 //
 // The compiler auto-injects `import { fylo } from '../runtime/fylo-global.js'`
 // when it detects bare `fylo` references in companion scripts. This shim
 // preserves that import path while the implementation lives in fylo-browser-sync.js.
 //
-// Deprecated modules (kept for one release, not imported at runtime):
-//   fylo-local.js — replaced by @d31ma/fylo/browser OPFS storage
-//   fylo-opfs-fs.js — built into @d31ma/fylo/browser, never wired into runtime
-
 export { fylo, createFyloClient } from './fylo-browser-sync.js';

--- a/src/server/fylo-browser/fylo-browser.js
+++ b/src/server/fylo-browser/fylo-browser.js
@@ -1,9 +1,9 @@
 // @ts-check
 //
-// Tachyon Fylo browser route registration — delegates to FyloGateway which
-// wraps the official @d31ma/fylo/server HTTP handler and adds Tachyon-specific
-// endpoints (SSE streaming, deleted-doc management, rebuild, encryption
-// redaction, browser UI shell).
+// Tachyon Fylo browser route registration — delegates to FyloGateway, which
+// drives the FYLO GitHub release binary and adds Tachyon-specific endpoints
+// (SSE streaming, deleted-doc management, rebuild, encryption redaction,
+// browser UI shell).
 //
 // Kept as a thin facade so existing callers (Yon.createServerRoutes) and the
 // loadCollectionSchema test export don't need to change their import paths.

--- a/src/vendor/fylo/fylo-web.mjs
+++ b/src/vendor/fylo/fylo-web.mjs
@@ -3824,8 +3824,21 @@ class SyncEngine {
       } catch {
         if (signal.aborted)
           return;
-        await this._pollOnce(collection);
-        await new Promise((r) => setTimeout(r, this.pingMs));
+        try {
+          await this._pollOnce(collection);
+        } catch {}
+        await new Promise((resolve) => {
+          let timer;
+          const onAbort = () => {
+            clearTimeout(timer);
+            resolve(undefined);
+          };
+          timer = setTimeout(() => {
+            signal.removeEventListener("abort", onAbort);
+            resolve(undefined);
+          }, this.pingMs);
+          signal.addEventListener("abort", onAbort, { once: true });
+        });
       }
     }
   }

--- a/src/vendor/fylo/fylo-web.mjs
+++ b/src/vendor/fylo/fylo-web.mjs
@@ -3828,6 +3828,10 @@ class SyncEngine {
           await this._pollOnce(collection);
         } catch {}
         await new Promise((resolve) => {
+          if (signal.aborted) {
+            resolve(undefined);
+            return;
+          }
           let timer;
           const onAbort = () => {
             clearTimeout(timer);

--- a/website/README.md
+++ b/website/README.md
@@ -25,9 +25,9 @@ without a CDN inside a `default-src 'self'` content-security policy.
   from `client/shared/data/docs.json`.
 
 The shell is polymorphic: desktop gets full app-bar navigation, while
-below-desktop layouts use an off-canvas drawer with roomier touch targets.
-Content-level layouts use container queries, and the platform-aware Tac
-globals stamp `data-environment` / `data-platform` onto `<body>`.
+below-desktop layouts use a right-side dropdown menu with roomier touch
+targets. Content-level layouts use container queries, and the platform-aware
+Tac globals stamp `data-environment` / `data-platform` onto `<body>`.
 
 The same `client/` source bundles into `dist/web/`, `dist/macos/`,
 `dist/windows/`, `dist/linux/`, `dist/ios/`, and `dist/android/`. The

--- a/website/client/components/home/yon/tac.css
+++ b/website/client/components/home/yon/tac.css
@@ -42,16 +42,31 @@
   gap: 1rem;
   align-items: stretch;
   grid-template-columns: 1fr;
+  min-width: 0;
 }
 
 .yon-card {
+  display: block;
+  box-sizing: border-box;
+  width: 100%;
   height: 100%;
   min-height: 19.8125rem;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .yon-card > .w-card {
+  box-sizing: border-box;
+  width: 100%;
   height: 100%;
   min-height: inherit;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.yon-card pre,
+.yon-card code {
+  max-width: 100%;
 }
 
 .yon-grid p {

--- a/website/client/components/site/header/tac.css
+++ b/website/client/components/site/header/tac.css
@@ -3,12 +3,67 @@ a {
   color: inherit;
 }
 
+.site-header-row {
+  position: relative;
+}
+
 .brand-name {
   font-size: 0.95rem;
+}
+
+.header-burger {
+  border: 1px solid color-mix(in srgb, var(--w-text) 12%, transparent);
+  border-radius: calc(var(--w-radius) + 0.625rem);
+  background:
+    radial-gradient(circle at 32% 20%, color-mix(in srgb, var(--tachyon-from) 16%, transparent), transparent 40%),
+    color-mix(in srgb, var(--w-surface-container) 88%, transparent);
+}
+
+.menu-icon-close {
+  display: none;
+}
+
+.header-burger[aria-expanded="true"] .menu-icon-open {
+  display: none;
+}
+
+.header-burger[aria-expanded="true"] .menu-icon-close {
+  display: inline;
+}
+
+.header-mobile-menu {
+  position: absolute;
+  inset: calc(100% + var(--tac-safe-top, env(safe-area-inset-top, 0px))) 0 auto;
+  z-index: 39;
+  display: none;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.65rem clamp(1rem, 4vw, 1.5rem);
+  border-block: 1px solid color-mix(in srgb, var(--w-text) 10%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--w-surface) 94%, transparent), var(--w-surface-container-low)),
+    var(--w-surface);
+  box-shadow: 0 1rem 2.5rem color-mix(in srgb, #000 16%, transparent);
+}
+
+.header-mobile-menu.open {
+  display: flex;
+}
+
+.header-mobile-menu .mobile-menu-link {
+  justify-content: flex-start;
+  width: 100%;
+  min-height: 44px;
 }
 
 @media (max-width: 1024px) {
   .only-desktop {
     display: none;
+  }
+}
+
+@media (min-width: 1025px) {
+  .header-mobile-menu {
+    display: none !important;
   }
 }

--- a/website/client/components/site/header/tac.html
+++ b/website/client/components/site/header/tac.html
@@ -1,7 +1,5 @@
 <w-app-bar sticky scroll-behavior="elevate">
-  <w-container size="xl" class="w-row align-center ga-2 px-0">
-    <w-app-bar-nav-icon for="site-drawer" class="only-below-desktop" aria-label="Open site navigation"></w-app-bar-nav-icon>
-
+  <w-container size="xl" class="w-row align-center ga-2 px-0 site-header-row">
     <a href="/" class="w-row align-center ga-2 mr-auto" aria-label="Tachyon home">
       <img class="brand-mark" src="/shared/assets/logo.svg" alt="" width="28" height="28" />
       <span class="brand-name">TACHYON</span>
@@ -18,14 +16,24 @@
       ◐<span class="w-hide-phone"> Theme</span>
     </w-btn>
     <w-btn variant="text" size="sm" href="https://github.com/d31ma/Tachyon" target="_blank" rel="noopener" class="w-hide-phone">GitHub</w-btn>
+
+    <button
+      type="button"
+      class="w-btn w-btn-icon header-burger only-below-desktop"
+      aria-label="Menu"
+      aria-controls="mobile-menu"
+      aria-expanded="false"
+      w-dropdown-trigger
+    >
+      <span class="menu-icon menu-icon-open" aria-hidden="true">☰</span>
+      <span class="menu-icon menu-icon-close" aria-hidden="true">✕</span>
+    </button>
   </w-container>
 </w-app-bar>
 
-<w-navigation-drawer id="site-drawer" temporary label="Site navigation">
-  <w-list>
-    <w-list-item href="/" title="Home" subtitle="Why Tachyon"></w-list-item>
-    <w-list-item href="/atlas" title="Capability atlas" subtitle="Live in-browser demos"></w-list-item>
-    <w-list-item href="/docs" title="Documentation" subtitle="Guides and reference"></w-list-item>
-    <w-list-item href="https://github.com/d31ma/Tachyon" title="GitHub" subtitle="Website source"></w-list-item>
-  </w-list>
-</w-navigation-drawer>
+<nav id="mobile-menu" class="header-mobile-menu only-below-desktop" aria-label="Mobile navigation" w-dropdown>
+  <w-btn href="/" variant="text" class="mobile-menu-link">Home</w-btn>
+  <w-btn href="/atlas" variant="text" class="mobile-menu-link">Atlas</w-btn>
+  <w-btn href="/docs" variant="text" class="mobile-menu-link">Docs</w-btn>
+  <w-btn href="https://github.com/d31ma/Tachyon" target="_blank" rel="noopener" variant="text" class="mobile-menu-link">GitHub</w-btn>
+</nav>

--- a/website/client/components/site/header/tac.js
+++ b/website/client/components/site/header/tac.js
@@ -24,7 +24,7 @@ export default class extends Tac {
 
     menu.addEventListener('click', (event) => {
       if (!(event.target instanceof Element)) return
-      if (!event.target.closest('a[href]')) return
+      if (!event.target.closest('[href]')) return
       menu.classList.remove('open')
       trigger.setAttribute('aria-expanded', 'false')
     })

--- a/website/client/components/site/header/tac.js
+++ b/website/client/components/site/header/tac.js
@@ -13,5 +13,20 @@ export default class extends Tac {
     // never rerenders and its light-DOM components stay upgraded.
     document.body.dataset.environment = this.tac.platform.environment
     document.body.dataset.platform = this.tac.platform.platform
+    this.closeMobileMenuAfterNavigation()
+  }
+
+  closeMobileMenuAfterNavigation() {
+    const menu = document.getElementById('mobile-menu')
+    const trigger = document.querySelector('[aria-controls="mobile-menu"]')
+    if (!menu || !trigger) return
+    if (!trigger.hasAttribute('aria-expanded')) trigger.setAttribute('aria-expanded', 'false')
+
+    menu.addEventListener('click', (event) => {
+      if (!(event.target instanceof Element)) return
+      if (!event.target.closest('a[href]')) return
+      menu.classList.remove('open')
+      trigger.setAttribute('aria-expanded', 'false')
+    })
   }
 }

--- a/website/client/pages/atlas/tac.js
+++ b/website/client/pages/atlas/tac.js
@@ -1,8 +1,8 @@
 // @ts-check
 
-// The page root holds no reactive state, so the shell (header, drawers,
-// bottom navigation) renders once per navigation. Live state lives in the
-// panel components — the re-render boundary Tac recommends.
+// The page root holds no reactive state, so the shell renders once per
+// navigation. Live state lives in the panel components — the re-render
+// boundary Tac recommends.
 export default class {
   /** @type {string} */
   subtitle = 'A living tour of reactive interfaces, native web capabilities, polyglot Wasm workers, durable browser data and observable client flows — with no server behind it.'

--- a/website/client/shared/styles/site.css
+++ b/website/client/shared/styles/site.css
@@ -88,13 +88,13 @@ w-app-bar {
 
 /* ---- responsive navigation --------------------------------------------
    Navigation is viewport-driven, not device-driven. At desktop widths the app
-   bar shows the full inline nav; below desktop it collapses to the burger icon
-   (w-app-bar-nav-icon, shown via .only-below-desktop) that opens the temporary
-   side drawer. There is no bottom bar: as a fixed element at the viewport edge
-   it overlapped the OS gesture area on phones and intercepted taps. */
+   bar shows the full inline nav; below desktop it collapses to a right-aligned
+   dropdown menu, matching the FYLO site pattern. There is no bottom bar: as a
+   fixed element at the viewport edge it overlapped the OS gesture area on
+   phones and intercepted taps. */
 
 @media (max-width: 760px) {
-  /* Phone widths: hide the phone-hidden extras; the burger + drawer carry nav. */
+  /* Phone widths: hide the phone-hidden extras; the dropdown carries nav. */
   .w-hide-phone {
     display: none !important;
   }

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tac-h-yon",
-  "version": "26.28.02",
+  "version": "26.28.04",
   "private": true,
   "type": "module",
   "displayName": "Tachyon",

--- a/website/tests/dom/site.dom.test.js
+++ b/website/tests/dom/site.dom.test.js
@@ -47,12 +47,13 @@ describe('homepage DOM', () => {
         expect(shell).toContain('fylo-browser-path')
     })
 
-    test('renders the DuVay shell: app bar, burger nav-icon, drawer, footer', () => {
+    test('renders the DuVay shell: app bar, mobile dropdown, footer', () => {
         expect(home.document.querySelector('w-app-bar')).toBeTruthy()
-        // Below-desktop navigation is the burger icon that opens the side drawer —
-        // no bottom bar (it overlapped the OS gesture area on phones).
-        expect(home.document.querySelector('w-app-bar-nav-icon[for="site-drawer"]')).toBeTruthy()
-        expect(home.document.querySelector('w-navigation-drawer#site-drawer')).toBeTruthy()
+        // Below-desktop navigation is a right-aligned dropdown, matching FYLO's
+        // mobile shell. No bottom bar: it overlapped the OS gesture area.
+        expect(home.document.querySelector('button.header-burger[aria-controls="mobile-menu"]')).toBeTruthy()
+        expect(home.document.querySelector('nav#mobile-menu[w-dropdown]')).toBeTruthy()
+        expect(home.document.querySelector('w-navigation-drawer')).toBeFalsy()
         expect(home.document.querySelector('w-bottom-navigation')).toBeFalsy()
         expect(home.document.querySelector('w-footer')).toBeTruthy()
         expect(home.document.querySelector('img.brand-mark[src="/shared/assets/logo.svg"]')).toBeTruthy()

--- a/website/tests/dom/site.dom.test.js
+++ b/website/tests/dom/site.dom.test.js
@@ -78,6 +78,13 @@ describe('homepage DOM', () => {
             expect(hrefs).toContain(target)
         }
     })
+
+    test('mobile dropdown closes from href-bearing custom elements', async () => {
+        const source = await read('client/components/site/header/tac.js')
+
+        expect(source).toContain("closest('[href]')")
+        expect(source).not.toContain("closest('a[href]')")
+    })
 })
 
 describe('atlas DOM', () => {


### PR DESCRIPTION
## Summary
- bump Tachyon and website metadata to 26.28.04
- update the vendored FYLO browser bundle to the latest FYLO v26.28.04 release asset behavior
- keep FYLO binary/browser integration aligned with the GitHub binary-first flow
- include the latest website/docs polish and refreshed Graphify output

## Validation
- bun run typecheck
- bun --env-file=tests/.env.test test ./tests --max-concurrency=1 --timeout 120000 (519 pass)
- cd website && bun run test (19 pass)
- cd website && bun run bundle -- --target web
- git diff --check
- graphify update .

## Notes
- Verified local FYLO binary checksum against FYLO v26.28.04 macOS arm64 release checksum.
