### PR TITLE
Release 26.28.05

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,23 @@ Useful commands:
 <tr><td><code>ty serve</code></td><td>Shape-aware dev server — frontend, backend, or full-stack on one port</td></tr>
 <tr><td><code>ty bundle</code></td><td>Build static <code>dist/</code> output</td></tr>
 <tr><td><code>ty preview</code></td><td>Serve the built <code>dist/web</code> directory by default</td></tr>
+<tr><td><code>ty cache clean</code></td><td>Clear the standalone binary's materialized runtime cache</td></tr>
 </table>
 
 `ty serve` is shape-aware: `client/` only bundles and serves the frontend,
 `server/` only serves backend routes, apps with both folders run as a full-stack
 app on one port, and `client/` + `db/` apps mount Tachyon's built-in FYLO
 browser routes when `YON_DATA_BROWSER_ENABLED=true`.
+
+### Standalone Runtime Cache
+
+Live `Bun.build()` artifacts stay in memory while `ty serve` runs. The
+standalone `ty` binary stores only its materialized framework source files in a
+versioned OS cache so Bun can resolve them during a build: `~/Library/Caches/Tachyon`
+on macOS, `%LOCALAPPDATA%\\Tachyon\\Cache` on Windows, and
+`$XDG_CACHE_HOME/tachyon` (or `~/.cache/tachyon`) on Linux. Set
+`TACHYON_CACHE_DIR` to override the cache root, inspect it with `ty cache`, and
+remove only this runtime cache with `ty cache clean`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@d31ma/tachyon",
-  "version": "26.28.04",
+  "version": "26.28.05",
   "description": "A polyglot, file-system-routed full-stack framework for Bun",
   "author": "Chidelma",
   "license": "MIT",

--- a/src/cli/bundle.js
+++ b/src/cli/bundle.js
@@ -13,7 +13,7 @@ import { pathToFileURL } from "url";
 
 /**
  * @typedef {'file' | 'directory'} WatchTargetKind
- * @typedef {{ incremental?: boolean }} BundleWatcherOptions
+ * @typedef {{ incremental?: boolean, skipInitialBuild?: boolean }} BundleWatcherOptions
  * @typedef {import("../shared/native-targets.js").BundleTarget} BundleTarget
  */
 
@@ -587,7 +587,8 @@ async function watchPaths(onChange) {
  */
 export async function startBundleWatcher(options = {}) {
     const incremental = options.incremental ?? true;
-    if (!skipInitialBuild) {
+    const shouldSkipInitialBuild = options.skipInitialBuild ?? skipInitialBuild;
+    if (!shouldSkipInitialBuild) {
         await runBuild();
         incrementalReady = incremental && bundleTargets.length === 1;
     }
@@ -645,7 +646,7 @@ export async function startBundleWatcher(options = {}) {
         }
     };
 }
-if (import.meta.main) {
+export async function runBundleCommand() {
     if (!watchMode) {
         await runBuild();
     }
@@ -659,4 +660,7 @@ if (import.meta.main) {
         process.on('SIGTERM', shutdown);
         await new Promise(() => { });
     }
+}
+if (import.meta.main) {
+    await runBundleCommand();
 }

--- a/src/cli/cache.js
+++ b/src/cli/cache.js
@@ -1,0 +1,21 @@
+// @ts-check
+import TachyonRuntimeCache from '../shared/runtime-cache.js';
+
+/** @param {string[]} [args] */
+export async function runCacheCommand(args = process.argv.slice(2)) {
+    const action = args[0];
+    if (!action || action === 'status') {
+        const status = await TachyonRuntimeCache.status();
+        console.log(`Tachyon cache\n  Root: ${status.root}\n  Runtime entries: ${status.entries}`);
+        return;
+    }
+    if (action === 'clean') {
+        await TachyonRuntimeCache.clear();
+        console.log(`Cleared Tachyon runtime cache: ${TachyonRuntimeCache.runtimeRoot()}`);
+        return;
+    }
+    throw new Error(`Unknown cache command '${action}'. Use: ty cache [status|clean]`);
+}
+
+if (import.meta.main)
+    await runCacheCommand();

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -11,14 +11,16 @@
 //   ty bundle [--watch] …             build client + native artifacts
 //   ty native-bundle [--target <t>]   generate the native host only
 //   ty preview [--watch] …            preview a built bundle
+//   ty cache [status|clean]            inspect or clear standalone runtime cache
 //
-// The command modules run on import (top-level await + side effects), so we
-// normalize argv to `[exec, <command>, …args]` first — giving them the same
-// shape they'd see under `bun src/cli/<command>.js …` (flags from index 2).
+// Commands read flags from `process.argv`, so we normalize argv to
+// `[exec, <command>, …args]` first — giving them the same shape they'd see under
+// `bun src/cli/<command>.js …` (flags from index 2). Commands that expose an
+// explicit runner are called below; older command modules still run on import.
 
 import pkg from '../../package.json';
 
-const COMMANDS = ['init', 'serve', 'bundle', 'native-bundle', 'preview'];
+const COMMANDS = ['init', 'serve', 'bundle', 'native-bundle', 'preview', 'cache'];
 
 function usage() {
     console.log(`ty ${pkg.version} — Tachyon CLI
@@ -31,6 +33,7 @@ Commands:
   bundle             Build client + native artifacts
   native-bundle      Generate the native host only
   preview            Preview a built bundle
+  cache [status|clean] Inspect or clear standalone runtime cache
 
 Run 'ty <command> --help' for command-specific options.`);
 }
@@ -41,6 +44,28 @@ Run 'ty <command> --help' for command-specific options.`);
 const userArgs = process.argv.slice(2);
 const command = userArgs[0];
 const rest = userArgs.slice(1);
+
+async function runInternalAdapter() {
+    if (!command)
+        return false;
+    const normalized = command.replaceAll('\\', '/');
+    if (normalized.endsWith('/yon-js-runner.js') || normalized === 'yon-js-runner.js') {
+        process.argv = [process.argv[0], command, ...rest];
+        const { default: YonJsRunner } = await import('../server/process/adapters/yon-js-runner.js');
+        await YonJsRunner.run();
+        return true;
+    }
+    if (normalized.endsWith('/yon-compiled-runner.js') || normalized === 'yon-compiled-runner.js') {
+        process.argv = [process.argv[0], command, ...rest];
+        const { default: YonCompiledRunner } = await import('../server/process/adapters/yon-compiled-runner.js');
+        await YonCompiledRunner.run();
+        return true;
+    }
+    return false;
+}
+
+if (await runInternalAdapter())
+    process.exit(0);
 
 if (!command || command === '--help' || command === '-h' || command === 'help') {
     usage();
@@ -63,7 +88,8 @@ process.argv = [process.argv[0], command, ...rest];
 switch (command) {
     case 'init': await import('./init.js'); break;
     case 'serve': await import('./serve.js'); break;
-    case 'bundle': await import('./bundle.js'); break;
+    case 'bundle': await (await import('./bundle.js')).runBundleCommand(); break;
     case 'native-bundle': await import('./native-bundle.js'); break;
     case 'preview': await import('./preview.js'); break;
+    case 'cache': await (await import('./cache.js')).runCacheCommand(rest); break;
 }

--- a/src/cli/preview.js
+++ b/src/cli/preview.js
@@ -20,7 +20,6 @@ catch (error) {
     process.exit(1);
 }
 const WATCH_INTERVAL_MS = 300;
-const bundleCliPath = path.join(import.meta.dir, 'bundle.js');
 const previewLogger = logger.child({ scope: 'cli:preview' });
 
 /**
@@ -103,15 +102,23 @@ async function buildFingerprint() {
     return entries.flat().sort().join('|');
 }
 async function runFreshBundleBuild() {
-    const proc = Bun.spawn(['bun', bundleCliPath, '--target', previewTarget], {
-        cwd: process.cwd(),
-        env: process.env,
-        stdout: 'inherit',
-        stderr: 'inherit'
-    });
-    const exitCode = await proc.exited;
-    if (exitCode !== 0) {
-        throw new Error(`Bundle subprocess exited with code ${exitCode}`);
+    const previousTarget = process.env.TAC_BUNDLE_TARGET;
+    const previousTargets = process.env.TAC_BUNDLE_TARGETS;
+    process.env.TAC_BUNDLE_TARGET = previewTarget;
+    process.env.TAC_BUNDLE_TARGETS = previewTarget;
+    try {
+        const { runBuild } = await import('./bundle.js');
+        await runBuild();
+    }
+    finally {
+        if (previousTarget === undefined)
+            Reflect.deleteProperty(process.env, 'TAC_BUNDLE_TARGET');
+        else
+            process.env.TAC_BUNDLE_TARGET = previousTarget;
+        if (previousTargets === undefined)
+            Reflect.deleteProperty(process.env, 'TAC_BUNDLE_TARGETS');
+        else
+            process.env.TAC_BUNDLE_TARGETS = previousTargets;
     }
 }
 async function startPreviewBundleWatcher() {

--- a/src/cli/serve.js
+++ b/src/cli/serve.js
@@ -29,8 +29,6 @@ const start = Date.now();
 let bundleWatcher = null;
 const distPath = path.resolve(process.env.YON_DIST_PATH ?? path.join(process.cwd(), 'dist'));
 let frontendDistPath = distPath;
-const bundleCliPath = `${import.meta.dir}/bundle.js`;
-const hotReloadClientPath = path.join(import.meta.dir, '../runtime/hot-reload-client.js');
 const serveLogger = logger.child({ scope: 'cli:serve' });
 /** @type {Set<HmrClient>} */
 const hmrClients = new Set();
@@ -55,6 +53,13 @@ async function pathExists(path) {
     catch {
         return false;
     }
+}
+async function hotReloadClientSource() {
+    if (import.meta.dir.startsWith('/$bunfs/')) {
+        const mod = /** @type {{ default: string }} */ (/** @type {unknown} */ (await import('../runtime/hot-reload-client.js', { with: { type: 'text' } })));
+        return mod.default;
+    }
+    return Bun.file(path.join(import.meta.dir, '../runtime/hot-reload-client.js')).text();
 }
 /**
  * @param {string} root
@@ -189,13 +194,10 @@ if (frontendEnabled) {
 }
 await configureRoutes();
 if (hmrEnabled && !skipBundle) {
-    const bundleArgs = frontendEnabled
-        ? ['bun', bundleCliPath, '--watch', '--skip-initial-build']
-        : ['bun', bundleCliPath, '--watch'];
-    bundleWatcher = Bun.spawn(bundleArgs, {
-        cwd: process.cwd(),
-        stdout: 'inherit',
-        stderr: 'inherit'
+    const { startBundleWatcher } = await import('./bundle.js');
+    bundleWatcher = await startBundleWatcher({
+        incremental: true,
+        skipInitialBuild: frontendEnabled,
     });
 }
 if (frontendEnabled) {
@@ -346,12 +348,12 @@ const server = Bun.serve({
         if (hmrEnabled
             && pathname === "/hot-reload-client.js"
             && (req.method === 'GET' || req.method === 'HEAD')) {
-            return new Response(req.method === 'HEAD' ? null : Bun.file(hotReloadClientPath), {
+            return Promise.resolve(req.method === 'HEAD' ? '' : hotReloadClientSource()).then((source) => new Response(req.method === 'HEAD' ? null : source, {
                 headers: {
                     "Content-Type": "text/javascript; charset=utf-8",
                     "Cache-Control": "no-cache, must-revalidate",
                 },
-            });
+            }));
         }
         if (frontendEnabled) {
             const allowRootFallback = wantsHtmlDocument(req) && !isAssetRequest(pathname);
@@ -374,7 +376,7 @@ process.on('SIGINT', () => {
     for (const watcher of hmrWatchers)
         watcher.close();
     Pool.clearWarmedProcesses();
-    bundleWatcher?.kill();
+    bundleWatcher?.close?.();
     server.stop();
     serveLogger.info('Server stopped', { signal: 'SIGINT' });
     process.exit(0);
@@ -384,7 +386,7 @@ process.on('SIGTERM', () => {
     for (const watcher of hmrWatchers)
         watcher.close();
     Pool.clearWarmedProcesses();
-    bundleWatcher?.kill();
+    bundleWatcher?.close?.();
     server.stop();
     serveLogger.info('Server stopped', { signal: 'SIGTERM' });
     process.exit(0);

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -11,8 +11,9 @@ import { pathToFileURL } from "url";
 import { compileRustWorker } from "./wasm/rust-compiler.js";
 import { compileJavaScriptWorker, compileTypeScriptWorker } from "./wasm/javascript-compiler.js";
 import { buildRuntimeModule } from "./wasm/tac-wasm-compiler.js";
-import { EVENT_CAPTURE_SCRIPT } from "../runtime/event-hydration.js";
+import { EVENT_CAPTURE_SCRIPT } from "../runtime/event-capture-script.js";
 import { compileNativeWorkerExecutable } from "./native/worker-compiler.js";
+import TachyonRuntimeCache from "../shared/runtime-cache.js";
 /**
  * @typedef {import("bun").BunRequest} BunRequest
  * @typedef {import("bun").BunPlugin} BunPlugin
@@ -31,16 +32,92 @@ import { compileNativeWorkerExecutable } from "./native/worker-compiler.js";
  * @typedef {{ target: string, platform: string, environment: string, os: string, native: boolean, browser: boolean, web: boolean, desktop: boolean, mobile: boolean }} TacPlatformContext
  * @typedef {{ version: string, modules: Map<string, Function>, platform: TacPlatformContext, register: (id: string, factory: Function) => Function, load: (id: string) => Promise<Function> }} TacRegistry
  */
-const TEMPLATE_PATH = `${import.meta.dir}/render-template.js`;
-const SPA_RENDERER_PATH = `${import.meta.dir}/../runtime/spa-renderer.js`;
-const FYLO_LOCAL_WORKER_PATH = `${import.meta.dir}/../runtime/fylo-browser-worker.js`;
 const ROUTE_MANIFEST_PLACEHOLDER = '{"__tachyonPlaceholder":true}';
 const WRAPPER_MANIFEST_PLACEHOLDER = '{"__tachyonShellPlaceholder":true}';
-const NOT_FOUND_PATH = `${import.meta.dir}/../runtime/shells/not-found.html`;
-const APP_SHELL_PATH = `${import.meta.dir}/../runtime/shells/app.html`;
 const PRERENDER_WORKER_PATH = `${import.meta.dir}/../runtime/prerender-worker.js`;
 const MODULES_ROUTE_PREFIX = '/shared/modules';
 const IMPORT_MAP_PLACEHOLDER = '<!--__TACHYON_IMPORT_MAP__-->';
+const FRAMEWORK_SOURCE_ROOT = path.resolve(import.meta.dir, '..');
+const EVENT_CAPTURE_SCRIPT_SOURCE = `// @ts-check\nexport const EVENT_CAPTURE_SCRIPT = ${JSON.stringify(EVENT_CAPTURE_SCRIPT)};\n`;
+/** @type {Promise<string> | null} */
+let embeddedFrameworkRootPromise = null;
+const EMBEDDED_FRAMEWORK_FILES = [
+    'compiler/render-template.js',
+    'runtime/shells/app.html',
+    'runtime/shells/not-found.html',
+    'runtime/spa-renderer.js',
+    'runtime/dom-helpers.js',
+    'runtime/static-cache.js',
+    'runtime/event-capture-script.js',
+    'runtime/event-hydration.js',
+    'runtime/component-registry.js',
+    'runtime/service-worker-policy.js',
+    'runtime/fylo-browser-worker.js',
+    'runtime/hot-reload-client.js',
+    'runtime/tachyon-sw.js',
+    'runtime/decorators.js',
+    'runtime/fylo-global.js',
+    'runtime/fylo-browser-sync.js',
+    'runtime/browser-cache.js',
+    'runtime/tac-worker.js',
+    'vendor/fylo/fylo-web.mjs',
+];
+function isEmbeddedFrameworkRuntime() {
+    return import.meta.dir.startsWith('/$bunfs/');
+}
+/** @param {Promise<unknown>} modulePromise */
+async function textModule(modulePromise) {
+    return /** @type {{ default: string }} */ (await modulePromise).default;
+}
+/** @param {string} relativePath */
+async function loadEmbeddedFrameworkSource(relativePath) {
+    switch (relativePath) {
+        case 'compiler/render-template.js': return textModule(import('./render-template.js', { with: { type: 'text' } }));
+        case 'runtime/shells/app.html': return textModule(import('../runtime/shells/app.html', { with: { type: 'text' } }));
+        case 'runtime/shells/not-found.html': return textModule(import('../runtime/shells/not-found.html', { with: { type: 'text' } }));
+        case 'runtime/spa-renderer.js': return textModule(import('../runtime/spa-renderer.js', { with: { type: 'text' } }));
+        case 'runtime/dom-helpers.js': return textModule(import('../runtime/dom-helpers.js', { with: { type: 'text' } }));
+        case 'runtime/static-cache.js': return textModule(import('../runtime/static-cache.js', { with: { type: 'text' } }));
+        case 'runtime/event-capture-script.js': return EVENT_CAPTURE_SCRIPT_SOURCE;
+        case 'runtime/event-hydration.js': return textModule(import('../runtime/event-hydration.js', { with: { type: 'text' } }));
+        case 'runtime/component-registry.js': return textModule(import('../runtime/component-registry.js', { with: { type: 'text' } }));
+        case 'runtime/service-worker-policy.js': return textModule(import('../runtime/service-worker-policy.js', { with: { type: 'text' } }));
+        case 'runtime/fylo-browser-worker.js': return textModule(import('../runtime/fylo-browser-worker.js', { with: { type: 'text' } }));
+        case 'runtime/hot-reload-client.js': return textModule(import('../runtime/hot-reload-client.js', { with: { type: 'text' } }));
+        case 'runtime/tachyon-sw.js': return textModule(import('../runtime/tachyon-sw.js', { with: { type: 'text' } }));
+        case 'runtime/decorators.js': return textModule(import('../runtime/decorators.js', { with: { type: 'text' } }));
+        case 'runtime/fylo-global.js': return textModule(import('../runtime/fylo-global.js', { with: { type: 'text' } }));
+        case 'runtime/fylo-browser-sync.js': return textModule(import('../runtime/fylo-browser-sync.js', { with: { type: 'text' } }));
+        case 'runtime/browser-cache.js': return textModule(import('../runtime/browser-cache.js', { with: { type: 'text' } }));
+        case 'runtime/tac-worker.js': return textModule(import('../runtime/tac-worker.js', { with: { type: 'text' } }));
+        case 'vendor/fylo/fylo-web.mjs': return textModule(import('../vendor/fylo/fylo-web.mjs', { with: { type: 'text' } }));
+        default: throw new Error(`Unknown embedded Tachyon framework file: ${relativePath}`);
+    }
+}
+async function embeddedFrameworkRoot() {
+    if (!isEmbeddedFrameworkRuntime())
+        return FRAMEWORK_SOURCE_ROOT;
+    embeddedFrameworkRootPromise ??= (async () => {
+        const files = await Promise.all(EMBEDDED_FRAMEWORK_FILES.map(async (relativePath) => ({
+            path: relativePath,
+            source: await loadEmbeddedFrameworkSource(relativePath),
+        })));
+        return TachyonRuntimeCache.materialize(files);
+    })();
+    return embeddedFrameworkRootPromise;
+}
+/** @param {string} relativePath */
+async function frameworkFilePath(relativePath) {
+    return path.join(await embeddedFrameworkRoot(), relativePath);
+}
+/**
+ * @param {string} relativePath
+ */
+async function frameworkText(relativePath) {
+    if (isEmbeddedFrameworkRuntime())
+        return loadEmbeddedFrameworkSource(relativePath);
+    return Bun.file(path.join(FRAMEWORK_SOURCE_ROOT, relativePath)).text();
+}
 /**
  * @param {string} routePath
  * @param {BodyInit} body
@@ -519,7 +596,7 @@ export default class Compiler {
                 frame.caseClosers.push('}}');
                 return `{ const __tc_case_value=(${caseExpr}); if(!${frame.matchedVar} && __tc_helpers__.matchSwitchCase(${frame.valueVar}, __tc_case_value)) { ${frame.matchedVar}=true;`;
             }
-            if (match === '`<case default="">`') {
+            if (match === '`<case default="">`' || match === '`<case default>`') {
                 if (frame.defaultSeen)
                     throw new Error(`Invalid Tac switch in '${sourceName}': only one default case is allowed per <switch>.`);
                 frame.defaultSeen = true;
@@ -1128,7 +1205,7 @@ export default class Compiler {
             .replaceAll('&', '&amp;')
             .replaceAll('"', '&quot;')
             .replaceAll('<', '&lt;');
-        let shellHTML = await Bun.file(APP_SHELL_PATH).text();
+        let shellHTML = await frameworkText('runtime/shells/app.html');
         shellHTML = shellHTML
             // Pre-hydration capture: classic inline script runs before the deferred
             // runtime module, recording dead-zone click/submit interactions for replay.
@@ -1155,7 +1232,15 @@ export default class Compiler {
         shellHTML = await Compiler.withWebAppManifest(shellHTML, assetPrefix);
         return withPublicBrowserEnv(shellHTML, assetPrefix);
     }
-    static createSpaRendererManifestPlugin() {
+    /**
+     * Stages an SPA renderer with its route metadata already substituted.
+     * Bun plugins are not reliably invoked from a compiled executable, so this
+     * keeps the runtime bundle identical for source and standalone `ty` use.
+     *
+     * @param {string} spaRendererPath
+     * @returns {Promise<{ entrypoint: string, root: string }>}
+     */
+    static async stageSpaRendererEntrypoint(spaRendererPath) {
         const routeManifestJSON = JSON.stringify(Router.routeSlugs);
         const wrapperManifestJSON = JSON.stringify(Compiler.wrapperPages);
         const assetPrefixLiteral = Compiler.isNativeBundle() ? './' : '/';
@@ -1165,65 +1250,72 @@ export default class Compiler {
         const escapedWrapperManifestJSON = wrapperManifestJSON
             .replaceAll('\\', '\\\\')
             .replaceAll("'", "\\'");
-        return /** @type {BunPlugin} */ ({
-            name: 'tachyon-manifest-inline',
-            setup(build) {
-                build.onLoad({ filter: /spa-renderer\.js$/ }, async ({ path: filePath }) => {
-                    if (path.resolve(filePath) !== path.resolve(SPA_RENDERER_PATH))
-                        return undefined;
-                    const source = await Bun.file(filePath).text();
-                    if (!source.includes(ROUTE_MANIFEST_PLACEHOLDER))
-                        throw new Error('Tac SPA renderer route manifest placeholder is missing');
-                    if (!source.includes(WRAPPER_MANIFEST_PLACEHOLDER))
-                        throw new Error('Tac SPA renderer wrapper manifest placeholder is missing');
-                    if (!source.includes('__TACHYON_ASSET_PREFIX__'))
-                        throw new Error('Tac SPA renderer asset prefix placeholder is missing');
-                    return {
-                        contents: source
-                            .replace(ROUTE_MANIFEST_PLACEHOLDER, escapedRouteManifestJSON)
-                            .replace(WRAPPER_MANIFEST_PLACEHOLDER, escapedWrapperManifestJSON)
-                            .replaceAll('__TACHYON_ASSET_PREFIX__', assetPrefixLiteral),
-                        loader: 'js',
-                    };
-                });
-            },
-        });
+        const source = await Bun.file(spaRendererPath).text();
+        if (!source.includes(ROUTE_MANIFEST_PLACEHOLDER))
+            throw new Error('Tac SPA renderer route manifest placeholder is missing');
+        if (!source.includes(WRAPPER_MANIFEST_PLACEHOLDER))
+            throw new Error('Tac SPA renderer wrapper manifest placeholder is missing');
+        if (!source.includes('__TACHYON_ASSET_PREFIX__'))
+            throw new Error('Tac SPA renderer asset prefix placeholder is missing');
+
+        const sourceDirectory = path.dirname(spaRendererPath);
+        const root = await mkdtemp(path.join(sourceDirectory, '.tachyon-spa-'));
+        const rewrittenSource = source
+            .replace(ROUTE_MANIFEST_PLACEHOLDER, escapedRouteManifestJSON)
+            .replace(WRAPPER_MANIFEST_PLACEHOLDER, escapedWrapperManifestJSON)
+            .replaceAll('__TACHYON_ASSET_PREFIX__', assetPrefixLiteral)
+            // The staged entrypoint lives in a temporary directory. Point its
+            // direct runtime imports back to their framework source directory.
+            .replace(/(\bfrom\s+['"])\.\/([^'"]+)(['"])/g, (_match, prefix, relativePath, suffix) => {
+                const resolvedPath = path.join(sourceDirectory, relativePath);
+                const stagedImportPath = path.relative(root, resolvedPath).split(path.sep).join('/');
+                return `${prefix}${stagedImportPath.startsWith('.') ? stagedImportPath : `./${stagedImportPath}`}${suffix}`;
+            });
+        const entrypoint = path.join(root, 'spa-renderer.js');
+        await writeFile(entrypoint, rewrittenSource);
+        return { entrypoint, root };
     }
     static async bundleBrowserRuntimeAssets() {
-        const entrypoints = [
-            SPA_RENDERER_PATH,
-            FYLO_LOCAL_WORKER_PATH,
-            `${import.meta.dir}/../runtime/hot-reload-client.js`,
-            `${import.meta.dir}/../runtime/tachyon-sw.js`,
-        ];
-        const mainEntrypoint = await Compiler.getMainEntrypointPath();
-        if (mainEntrypoint)
-            entrypoints.splice(1, 0, mainEntrypoint);
-        const result = await Bun.build({
-            entrypoints,
-            format: 'esm',
-            naming: '[name].[ext]',
-            minify: true,
-            splitting: true,
-            target: 'browser',
-            plugins: [Compiler.createSpaRendererManifestPlugin()],
-        });
-        const registeredRoutes = new Set();
-        for (const output of result.outputs) {
-            const routePath = Compiler.routePathFromBuildOutput(output.path);
-            Router.reqRoutes[routePath] = {
-                GET: () => typedResponse(routePath, output, output.type)
-            };
-            registeredRoutes.add(routePath);
+        const spaRendererPath = await frameworkFilePath('runtime/spa-renderer.js');
+        const stagedRenderer = await Compiler.stageSpaRendererEntrypoint(spaRendererPath);
+        try {
+            const entrypoints = [
+                stagedRenderer.entrypoint,
+                await frameworkFilePath('runtime/fylo-browser-worker.js'),
+                await frameworkFilePath('runtime/hot-reload-client.js'),
+                await frameworkFilePath('runtime/tachyon-sw.js'),
+            ];
+            const mainEntrypoint = await Compiler.getMainEntrypointPath();
+            if (mainEntrypoint)
+                entrypoints.splice(1, 0, mainEntrypoint);
+            const result = await Bun.build({
+                entrypoints,
+                format: 'esm',
+                naming: '[name].[ext]',
+                minify: true,
+                splitting: true,
+                target: 'browser',
+            });
+            const registeredRoutes = new Set();
+            for (const output of result.outputs) {
+                const routePath = Compiler.routePathFromBuildOutput(output.path);
+                Router.reqRoutes[routePath] = {
+                    GET: () => typedResponse(routePath, output, output.type)
+                };
+                registeredRoutes.add(routePath);
+            }
+            Router.reqRoutes[PUBLIC_BROWSER_ENV_PATH] = { GET: createPublicBrowserEnvResponse };
+            registeredRoutes.add(PUBLIC_BROWSER_ENV_PATH);
+            for (const staleRoute of Compiler.browserRuntimeRoutes) {
+                if (!registeredRoutes.has(staleRoute))
+                    delete Router.reqRoutes[staleRoute];
+            }
+            Compiler.browserRuntimeRoutes = registeredRoutes;
+            return [...registeredRoutes];
         }
-        Router.reqRoutes[PUBLIC_BROWSER_ENV_PATH] = { GET: createPublicBrowserEnvResponse };
-        registeredRoutes.add(PUBLIC_BROWSER_ENV_PATH);
-        for (const staleRoute of Compiler.browserRuntimeRoutes) {
-            if (!registeredRoutes.has(staleRoute))
-                delete Router.reqRoutes[staleRoute];
+        finally {
+            await rm(stagedRenderer.root, { recursive: true, force: true });
         }
-        Compiler.browserRuntimeRoutes = registeredRoutes;
-        return [...registeredRoutes];
     }
     /**
      * @param {string} distPath
@@ -1413,6 +1505,9 @@ export default class Compiler {
     }
     /** @param {string} distPath @param {string} pathname @param {string} shellHTML */
     static async renderPageDocumentIsolated(distPath, pathname, shellHTML) {
+        if (isEmbeddedFrameworkRuntime()) {
+            return Compiler.renderPageDocumentForWorker(distPath, pathname, shellHTML, Compiler.wrapperPages);
+        }
         const proc = Bun.spawn(['bun', PRERENDER_WORKER_PATH], {
             cwd: process.cwd(),
             stdin: 'pipe',
@@ -1461,7 +1556,8 @@ export default class Compiler {
         /** @type {{ outputFile: string, html: string }[]} */
         const renderedRoutes = [];
         let renderIndex = 0;
-        const renderWorkers = Array.from({ length: Math.min(Compiler.prerenderRenderConcurrency, routes.length) }, async () => {
+        const renderConcurrency = isEmbeddedFrameworkRuntime() ? 1 : Compiler.prerenderRenderConcurrency;
+        const renderWorkers = Array.from({ length: Math.min(renderConcurrency, routes.length) }, async () => {
             while (renderIndex < routes.length) {
                 const currentIndex = renderIndex++;
                 const route = routes[currentIndex];
@@ -1868,7 +1964,7 @@ export default class Compiler {
             .replaceAll(/`<loop :for="(.*?)">`|`<\/loop>`/g, (_, expr) => expr ? Compiler.compileLoopExpression(expr) : '}')
             .replaceAll(/`<logic :if="(.*?)">`/g, (_, expr) => `if(${expr}) {`)
             .replaceAll(/`<logic :else-if="(.*?)">`/g, (_, expr) => `else if(${expr}) {`)
-            .replaceAll(/(`<logic else="">`)|(`<\/logic>`)/g, (_, expr) => expr ? `else {` : '}');
+            .replaceAll(/`<logic else(?:="")?>`|`<\/logic>`/g, (match) => match.startsWith('`<logic') ? `else {` : '}');
         Compiler.assertControlDirectivesResolved(renderSource, publicPath);
         renderSource = Compiler.compileSwitchExpressions(renderSource, publicPath);
         // Bind dynamic attributes :attr="expr" → attr="${escaped expr}"
@@ -2086,7 +2182,7 @@ with (__tc_scope__) {
         return elements;
     };
 }`;
-        let code = await Bun.file(TEMPLATE_PATH).text();
+        let code = await frameworkText('compiler/render-template.js');
         code = code.split('// module_imports').join(moduleImports.join(',\n'));
         code = code.split('"__TY_FACTORY_SOURCE__"').join(JSON.stringify(factorySource));
         code = code.split('"__TY_MODULE_PATH__"').join(JSON.stringify(publicPath));
@@ -2162,9 +2258,6 @@ ${transformed}
     static createCompanionScriptPlugin(sourcePath) {
         const filter = Compiler.createFilePathFilter(sourcePath);
         const tacInline = `var __tc_noopPlatform__=Object.freeze({target:"web",platform:"web",environment:"browser",os:"unknown",browserOS:"unknown",native:!1,browser:!0,web:!0,desktop:!1,mobile:!1});var __tc_noopHelpers__={isBrowser:!1,isServer:!0,bindPersistentFields:()=>{},env:(_,f)=>f,platform:__tc_noopPlatform__,props:{},fetch:(i,n)=>fetch(i,n),onMount:()=>{},publish:()=>!1,rerender:()=>{},subscribe:(_,c)=>typeof c=="function"?()=>{}:c};class Tac{props;tac;constructor(props={},tac=__tc_noopHelpers__){this.props=props,this.tac=tac}}`;
-        const decoratorsEntryPath = `${import.meta.dir}/../runtime/decorators.js`;
-        const fyloGlobalEntryPath = `${import.meta.dir}/../runtime/fylo-global.js`;
-        const tacWorkerEntryPath = `${import.meta.dir}/../runtime/tac-worker.js`;
         return /** @type {BunPlugin} */ ({
             name: `tachyon-tac-companion:${sourcePath}`,
             target: /** @type {import("bun").Target} */ ('browser'),
@@ -2174,14 +2267,17 @@ ${transformed}
                     Compiler.assertNoRemovedDecorators(contents, sourcePath);
                     const decoratorNames = Compiler.findReferencedDecorators(contents);
                     if (decoratorNames.length > 0) {
+                        const decoratorsEntryPath = await frameworkFilePath('runtime/decorators.js');
                         const importPath = Compiler.toRelativeImportPath(sourcePath, decoratorsEntryPath);
                         contents = `import { ${decoratorNames.join(', ')} } from ${JSON.stringify(importPath)};\n${contents}`;
                     }
                     if (Compiler.referencesFyloGlobal(contents)) {
+                        const fyloGlobalEntryPath = await frameworkFilePath('runtime/fylo-global.js');
                         const importPath = Compiler.toRelativeImportPath(sourcePath, fyloGlobalEntryPath);
                         contents = `import { fylo } from ${JSON.stringify(importPath)};\n${contents}`;
                     }
                     if (Compiler.referencesTacFetch(contents)) {
+                        const tacWorkerEntryPath = await frameworkFilePath('runtime/tac-worker.js');
                         const importPath = Compiler.toRelativeImportPath(sourcePath, tacWorkerEntryPath);
                         contents = `import { fetch } from ${JSON.stringify(importPath)};\n${contents}`;
                     }
@@ -3549,8 +3645,10 @@ async function __tac_resolve_native_response__(response) {
         const nfFile = Bun.file(`${process.cwd()}/404.html`);
         const nfContent = await nfFile.exists()
             ? await nfFile.text()
-            : await Bun.file(NOT_FOUND_PATH).text();
-        const nfSourcePath = await nfFile.exists() ? `${process.cwd()}/404.html` : NOT_FOUND_PATH;
+            : await frameworkText('runtime/shells/not-found.html');
+        const nfSourcePath = await nfFile.exists()
+            ? `${process.cwd()}/404.html`
+            : await frameworkFilePath('runtime/shells/not-found.html');
         const nfData = await Compiler.extractComponents(nfContent, nfSourcePath, 'pages', '404.html');
         await Compiler.registerModule(nfData, '404.html', 'pages', nfSourcePath);
     }

--- a/src/runtime/dom-helpers.js
+++ b/src/runtime/dom-helpers.js
@@ -23,6 +23,44 @@ export function findEventTarget(element, eventName) {
 }
 
 /**
+ * Finds the element that owns an in-app navigation request. Native anchors are
+ * supported directly; custom elements can opt in by exposing an `href`
+ * attribute, which is how DuVay's `<w-btn>` represents link buttons.
+ *
+ * @param {Element} element
+ * @returns {boolean}
+ */
+function isNavigationTarget(element) {
+    return element.hasAttribute('href')
+        && !element.hasAttribute('disabled')
+        && (element.localName === 'a' || element.localName.includes('-'));
+}
+
+/**
+ * Resolves a navigation target across regular and shadow DOM. The composed
+ * path makes native links rendered inside a web component visible; the host
+ * fallback supports light-DOM components that expose `href` themselves.
+ *
+ * @param {Event} event
+ * @returns {Element | null}
+ */
+export function findNavigationTarget(event) {
+    if (typeof event.composedPath === 'function') {
+        for (const node of event.composedPath()) {
+            if (node instanceof Element && isNavigationTarget(node))
+                return node;
+        }
+    }
+    let candidate = event.target instanceof Element ? event.target : null;
+    while (candidate && candidate !== document.body) {
+        if (isNavigationTarget(candidate))
+            return candidate;
+        candidate = candidate.parentElement;
+    }
+    return null;
+}
+
+/**
  * Builds the event context used by the value-binding rerender path while
  * preserving DOM-style `$event.target.value` handler access.
  * @param {Element & { value?: unknown }} element

--- a/src/runtime/event-capture-script.js
+++ b/src/runtime/event-capture-script.js
@@ -1,0 +1,25 @@
+// @ts-check
+/**
+ * Inline, dependency-free capture script for the SSR shell. Must run before the
+ * runtime module. Sets `window.__tacEventCapture = { queue, onIntent, stop }`.
+ */
+export const EVENT_CAPTURE_SCRIPT = `(function(){
+  var TYPES=['click','submit'];
+  var q=[];
+  function tacTarget(el){
+    for(var n=el; n && n!==document.body && n!==document; n=n.parentElement){
+      if(n.hasAttribute('href') && (n.tagName==='A' || n.tagName.indexOf('-')!==-1) && !n.hasAttribute('disabled')) return n;
+      var a=n.attributes; for(var i=0;i<a.length;i++){ if(a[i].name.indexOf('data-tac-on-')===0) return n; }
+    }
+    return null;
+  }
+  function rec(e){
+    var t=e.target; if(!t || t.nodeType!==1) return;
+    var handler=tacTarget(t); if(!handler) return;
+    q.push({type:e.type, target:handler});
+    if(e.type==='click'||e.type==='submit') e.preventDefault();
+    var c=window.__tacEventCapture; if(c && c.onIntent) c.onIntent();
+  }
+  for(var i=0;i<TYPES.length;i++) document.addEventListener(TYPES[i], rec, true);
+  window.__tacEventCapture={queue:q, onIntent:null, stop:function(){ for(var i=0;i<TYPES.length;i++) document.removeEventListener(TYPES[i], rec, true); }};
+})();`;

--- a/src/runtime/event-hydration.js
+++ b/src/runtime/event-hydration.js
@@ -17,31 +17,7 @@
  *     wiring off the critical path. On flush it registers the compile-time event
  *     set and replays the captured queue through the real delegation.
  */
-
-/**
- * Inline, dependency-free capture script for the SSR shell. Must run before the
- * runtime module. Sets `window.__tacEventCapture = { queue, onIntent, stop }`.
- */
-export const EVENT_CAPTURE_SCRIPT = `(function(){
-  var TYPES=['click','submit'];
-  var q=[];
-  function tacTarget(el){
-    for(var n=el; n && n!==document.body && n!==document; n=n.parentElement){
-      if(n.tagName==='A' && n.hasAttribute('href')) return n;
-      var a=n.attributes; for(var i=0;i<a.length;i++){ if(a[i].name.indexOf('data-tac-on-')===0) return n; }
-    }
-    return null;
-  }
-  function rec(e){
-    var t=e.target; if(!t || t.nodeType!==1) return;
-    var handler=tacTarget(t); if(!handler) return;
-    q.push({type:e.type, target:handler});
-    if(e.type==='click'||e.type==='submit') e.preventDefault();
-    var c=window.__tacEventCapture; if(c && c.onIntent) c.onIntent();
-  }
-  for(var i=0;i<TYPES.length;i++) document.addEventListener(TYPES[i], rec, true);
-  window.__tacEventCapture={queue:q, onIntent:null, stop:function(){ for(var i=0;i<TYPES.length;i++) document.removeEventListener(TYPES[i], rec, true); }};
-})();`;
+export { EVENT_CAPTURE_SCRIPT } from './event-capture-script.js';
 
 /**
  * @typedef {{ type: string, target: EventTarget & { isConnected?: boolean } }} CapturedEvent

--- a/src/runtime/spa-renderer.js
+++ b/src/runtime/spa-renderer.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { cleanBooleanAttrs, createValueEventDetail, findEventTarget, morphChildren, parseFragment, parseParams, resolveHandler } from './dom-helpers.js';
+import { cleanBooleanAttrs, createValueEventDetail, findEventTarget, findNavigationTarget, morphChildren, parseFragment, parseParams, resolveHandler } from './dom-helpers.js';
 import { cacheModuleResponse, clearStaticCache, precacheModules } from './static-cache.js';
 import { createDeferredDelegation } from './event-hydration.js';
 import { createComponentRegistry } from './component-registry.js';
@@ -310,21 +310,23 @@ function findDelegatedTarget(event, eventName) {
  * @param {Event} event
  */
 function handleDelegatedEvent(eventName, event) {
-    const eventTarget = event.target instanceof Element ? event.target : null;
     if (eventName === 'click') {
-        const anchor = /** @type {HTMLAnchorElement | null} */ (eventTarget?.closest('a[href]'));
-        if (anchor) {
-            const url = new URL(anchor.href, location.origin);
+        const navigationTarget = findNavigationTarget(event);
+        if (navigationTarget) {
+            const href = navigationTarget.getAttribute('href');
+            if (!href)
+                return;
+            const url = new URL(href, location.origin);
             const hasModifierKey = event instanceof MouseEvent
                 && (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey);
             const isPrimaryClick = !(event instanceof MouseEvent) || event.button === 0;
-            const target = anchor.getAttribute('target');
+            const target = navigationTarget.getAttribute('target');
             const isSameDocumentHash = url.origin === location.origin
                 && url.pathname === location.pathname
                 && url.search === location.search
                 && Boolean(url.hash);
             const allowSpaNavigation = url.origin === location.origin
-                && !anchor.hasAttribute('download')
+                && !navigationTarget.hasAttribute('download')
                 && !hasModifierKey
                 && isPrimaryClick
                 && (!target || target === '_self')

--- a/src/server/process/adapters/yon-js-runner.js
+++ b/src/server/process/adapters/yon-js-runner.js
@@ -1,6 +1,7 @@
 // @ts-check
+import NdjsonProcessClient from '../../../vendor/shared/ndjson-process-client.mjs';
 
-class YonJsRunner {
+export default class YonJsRunner {
     static RESPONSE_START = '\x1fTACHYON_RESPONSE\x1e';
     static RESPONSE_END = '\x1eTACHYON_RESPONSE\x1f';
 
@@ -152,10 +153,22 @@ class YonJsRunner {
         }
         YonJsRunner.writeResponseFrame(YonJsRunner.serialize(result));
     }
+
+    static async runMain() {
+        try {
+            await YonJsRunner.run();
+        }
+        catch (error) {
+            const message = error instanceof Error ? error.stack || error.message : String(error);
+            Bun.stderr.write(message);
+            process.exitCode = 1;
+        }
+        finally {
+            await NdjsonProcessClient.closeAll();
+        }
+    }
 }
 
-YonJsRunner.run().catch((error) => {
-    const message = error instanceof Error ? error.stack || error.message : String(error);
-    Bun.stderr.write(message);
-    process.exit(1);
-});
+if (import.meta.main) {
+    await YonJsRunner.runMain();
+}

--- a/src/server/yon.js
+++ b/src/server/yon.js
@@ -10,6 +10,7 @@ import YonRealtime from "./realtime/realtime.js";
 import Telemetry from './observability/telemetry.js';
 import { withPublicBrowserEnv } from './http/browser-env.js';
 import logger from './observability/logger.js';
+import APP_SHELL_SOURCE from "../runtime/shells/app.html" with { type: "text" };
 
 /**
  * @typedef {import("bun").BunRequest} BunRequest
@@ -244,7 +245,7 @@ export default class Yon {
     static async renderShellHTML(options = {}) {
         const includeHotReloadClient = options.includeHotReloadClient === true;
         const fyloBrowserPath = process.env.YON_DATA_BROWSER_PATH || '/_fylo';
-        let shellHTML = await Bun.file(`${import.meta.dir}/../runtime/shells/app.html`).text();
+        let shellHTML = /** @type {string} */ (/** @type {unknown} */ (APP_SHELL_SOURCE));
         shellHTML = shellHTML
             .replace('<!--__TACHYON_DEV_HEAD__-->', includeHotReloadClient
                 ? '    <script type="module" src="/hot-reload-client.js"></script>'

--- a/src/shared/runtime-cache.js
+++ b/src/shared/runtime-cache.js
@@ -1,0 +1,188 @@
+// @ts-check
+import { mkdir, mkdtemp, open, readFile, readdir, rename, rm, stat, unlink, writeFile } from 'fs/promises';
+import { homedir } from 'os';
+import path from 'path';
+
+const CACHE_LAYOUT_VERSION = 1;
+const CACHE_LOCK_TIMEOUT_MS = 30_000;
+const STALE_CACHE_LOCK_MS = 60_000;
+
+/**
+ * Stores source files embedded in a compiled `ty` binary where Bun can resolve
+ * them during a runtime build. Build artifacts themselves remain in memory.
+ */
+export default class TachyonRuntimeCache {
+    /** @returns {string} */
+    static cacheRoot() {
+        const override = process.env.TACHYON_CACHE_DIR?.trim();
+        if (override)
+            return path.resolve(override);
+        const home = process.env.HOME || process.env.USERPROFILE || homedir();
+        if (process.platform === 'darwin')
+            return path.join(home, 'Library', 'Caches', 'Tachyon');
+        if (process.platform === 'win32')
+            return path.join(process.env.LOCALAPPDATA || path.join(home, 'AppData', 'Local'), 'Tachyon', 'Cache');
+        return path.join(process.env.XDG_CACHE_HOME || path.join(home, '.cache'), 'tachyon');
+    }
+
+    /** @returns {string} */
+    static runtimeRoot() {
+        return path.join(TachyonRuntimeCache.cacheRoot(), 'runtime');
+    }
+
+    /** @param {string} source */
+    static hash(source) {
+        return Bun.hash(source).toString(16);
+    }
+
+    /**
+     * @param {Array<{ path: string, source: string }>} files
+     * @returns {Array<{ path: string, source: string, hash: string }>}
+     */
+    static normalizeFiles(files) {
+        const seen = new Set();
+        return files.map((file) => {
+            const relativePath = path.normalize(file.path).replaceAll('\\', '/');
+            if (!relativePath || path.isAbsolute(relativePath) || relativePath === '..' || relativePath.startsWith('../'))
+                throw new Error(`Invalid Tachyon runtime cache path: ${file.path}`);
+            if (typeof file.source !== 'string')
+                throw new Error(`Tachyon runtime cache source must be text: ${relativePath}`);
+            if (seen.has(relativePath))
+                throw new Error(`Duplicate Tachyon runtime cache path: ${relativePath}`);
+            seen.add(relativePath);
+            return { path: relativePath, source: file.source, hash: TachyonRuntimeCache.hash(file.source) };
+        }).sort((left, right) => left.path.localeCompare(right.path));
+    }
+
+    /** @param {Array<{ path: string, hash: string }>} files */
+    static cacheKey(files) {
+        return TachyonRuntimeCache.hash(JSON.stringify({ layout: CACHE_LAYOUT_VERSION, files }));
+    }
+
+    /**
+     * @param {string} root
+     * @param {string} key
+     * @param {Array<{ path: string, hash: string }>} files
+     */
+    static async isValid(root, key, files) {
+        try {
+            const manifest = JSON.parse(await readFile(path.join(root, 'manifest.json'), 'utf8'));
+            if (manifest.layout !== CACHE_LAYOUT_VERSION || manifest.key !== key || !Array.isArray(manifest.files))
+                return false;
+            if (JSON.stringify(manifest.files) !== JSON.stringify(files))
+                return false;
+            for (const file of files) {
+                const source = await readFile(path.join(root, file.path), 'utf8');
+                if (TachyonRuntimeCache.hash(source) !== file.hash)
+                    return false;
+            }
+            return true;
+        }
+        catch {
+            return false;
+        }
+    }
+
+    /**
+     * Ensures only one process repairs a content-addressed cache entry at once.
+     * @param {string} lockPath
+     * @param {string} targetRoot
+     * @param {string} key
+     * @param {Array<{ path: string, hash: string }>} files
+     * @returns {Promise<import('fs/promises').FileHandle | null>}
+     */
+    static async acquireLock(lockPath, targetRoot, key, files) {
+        const deadline = Date.now() + CACHE_LOCK_TIMEOUT_MS;
+        while (Date.now() < deadline) {
+            try {
+                return await open(lockPath, 'wx');
+            }
+            catch (error) {
+                if (!(error instanceof Error) || !('code' in error) || error.code !== 'EEXIST')
+                    throw error;
+                if (await TachyonRuntimeCache.isValid(targetRoot, key, files))
+                    return null;
+                try {
+                    const lock = await stat(lockPath);
+                    if (Date.now() - lock.mtimeMs > STALE_CACHE_LOCK_MS)
+                        await unlink(lockPath);
+                }
+                catch {
+                    // A competing process may have just released the lock.
+                }
+                await Bun.sleep(25);
+            }
+        }
+        throw new Error(`Timed out waiting for Tachyon runtime cache: ${targetRoot}`);
+    }
+
+    /**
+     * Materializes a validated, content-addressed framework source tree.
+     * @param {Array<{ path: string, source: string }>} files
+     * @returns {Promise<string>}
+     */
+    static async materialize(files) {
+        const normalizedFiles = TachyonRuntimeCache.normalizeFiles(files);
+        const manifestFiles = normalizedFiles.map(({ path, hash }) => ({ path, hash }));
+        const key = TachyonRuntimeCache.cacheKey(manifestFiles);
+        const runtimeRoot = TachyonRuntimeCache.runtimeRoot();
+        const targetRoot = path.join(runtimeRoot, key);
+        if (await TachyonRuntimeCache.isValid(targetRoot, key, manifestFiles))
+            return targetRoot;
+
+        await mkdir(runtimeRoot, { recursive: true });
+        const lockPath = `${targetRoot}.lock`;
+        const lock = await TachyonRuntimeCache.acquireLock(lockPath, targetRoot, key, manifestFiles);
+        if (!lock)
+            return targetRoot;
+        let stagingRoot = '';
+        try {
+            if (await TachyonRuntimeCache.isValid(targetRoot, key, manifestFiles))
+                return targetRoot;
+            stagingRoot = await mkdtemp(path.join(runtimeRoot, '.staging-'));
+            for (const file of normalizedFiles) {
+                const outputPath = path.join(stagingRoot, file.path);
+                await mkdir(path.dirname(outputPath), { recursive: true });
+                await writeFile(outputPath, file.source);
+            }
+            await writeFile(path.join(stagingRoot, 'manifest.json'), JSON.stringify({
+                layout: CACHE_LAYOUT_VERSION,
+                key,
+                files: manifestFiles,
+            }, null, 2));
+
+            if (await TachyonRuntimeCache.isValid(targetRoot, key, manifestFiles))
+                return targetRoot;
+            await rm(targetRoot, { recursive: true, force: true });
+            await rename(stagingRoot, targetRoot);
+            return targetRoot;
+        }
+        finally {
+            if (stagingRoot)
+                await rm(stagingRoot, { recursive: true, force: true });
+            await lock.close();
+            await unlink(lockPath).catch(() => {});
+        }
+    }
+
+    /** @returns {Promise<{ root: string, runtimeRoot: string, entries: number }>} */
+    static async status() {
+        const runtimeRoot = TachyonRuntimeCache.runtimeRoot();
+        try {
+            const entries = await readdir(runtimeRoot, { withFileTypes: true });
+            return {
+                root: TachyonRuntimeCache.cacheRoot(),
+                runtimeRoot,
+                entries: entries.filter((entry) => entry.isDirectory() && !entry.name.startsWith('.')).length,
+            };
+        }
+        catch {
+            return { root: TachyonRuntimeCache.cacheRoot(), runtimeRoot, entries: 0 };
+        }
+    }
+
+    /** Clears only content materialized by the standalone runtime. */
+    static async clear() {
+        await rm(TachyonRuntimeCache.runtimeRoot(), { recursive: true, force: true });
+    }
+}

--- a/src/vendor/chex/chex.mjs
+++ b/src/vendor/chex/chex.mjs
@@ -15,47 +15,15 @@
 // the schema. `request(op)` is a raw escape hatch resolving the full response.
 // Requests are queued: each resolves with its own response line, in order.
 
-import { spawn } from 'node:child_process'
+import NdjsonProcessClient from '../shared/ndjson-process-client.mjs'
 
-export class CHEX {
+export class CHEX extends NdjsonProcessClient {
     /** @param {{ binary?: string }} [opts] */
     constructor(opts = {}) {
-        this._proc = spawn(opts.binary ?? 'chex', ['exec', '--loop'], {
-            stdio: ['pipe', 'pipe', 'inherit']
-        })
-        this._queue = [] // pending { resolve, reject } in request order
-        this._buffer = ''
-        this._proc.stdout.setEncoding('utf8')
-        this._proc.stdout.on('data', (chunk) => this._onData(chunk))
-        this._proc.on('exit', () => {
-            const err = new Error('chex process exited')
-            for (const p of this._queue.splice(0)) p.reject(err)
-        })
-        // Surface spawn failures (e.g. binary missing) instead of crashing on an
-        // unhandled 'error' event.
-        this._proc.on('error', (err) => {
-            for (const p of this._queue.splice(0)) p.reject(err)
-        })
-    }
-
-    _onData(chunk) {
-        this._buffer += chunk
-        let nl
-        while ((nl = this._buffer.indexOf('\n')) !== -1) {
-            const line = this._buffer.slice(0, nl).trim()
-            this._buffer = this._buffer.slice(nl + 1)
-            if (!line) continue
-            const pending = this._queue.shift()
-            if (pending) pending.resolve(JSON.parse(line))
-        }
-    }
-
-    /** Send one raw machine-protocol op; resolves with the full response object. */
-    request(op) {
-        return new Promise((resolve, reject) => {
-            if (this._proc.exitCode !== null) return reject(new Error('chex process exited'))
-            this._queue.push({ resolve, reject })
-            this._proc.stdin.write(JSON.stringify(op) + '\n')
+        super({
+            name: 'chex',
+            command: NdjsonProcessClient.resolveCommand('chex', opts.binary),
+            args: ['exec', '--loop'],
         })
     }
 
@@ -74,12 +42,4 @@ export class CHEX {
         return this._op('validate', { schema, data, schemaDir })
     }
 
-    /** Close stdin so the loop ends, and wait for the process to exit. */
-    close() {
-        return new Promise((resolve) => {
-            if (this._proc.exitCode !== null) return resolve()
-            this._proc.on('exit', () => resolve())
-            this._proc.stdin.end()
-        })
-    }
 }

--- a/src/vendor/fylo/fylo-node.mjs
+++ b/src/vendor/fylo/fylo-node.mjs
@@ -20,7 +20,7 @@
 // object — use it for ops without a dedicated method (branching, schema, ...).
 // Requests are queued: each resolves with its own response line, in order.
 
-import { spawn } from 'node:child_process'
+import NdjsonProcessClient from '../shared/ndjson-process-client.mjs'
 
 // Property access that isn't a real method/field falls through to a collection
 // facade, so `db.users.put(...)` works alongside `db.putData('users', ...)`.
@@ -34,24 +34,15 @@ const FACADE = {
     }
 }
 
-export class Fylo {
+export class Fylo extends NdjsonProcessClient {
     /** @param {string} root @param {{ binary?: string, worm?: boolean }} [opts] */
     constructor(root, opts = {}) {
         const args = ['exec', '--loop', '--root', root]
         if (opts.worm) args.push('--worm')
-        this._proc = spawn(opts.binary ?? 'fylo', args, { stdio: ['pipe', 'pipe', 'inherit'] })
-        this._queue = [] // pending { resolve, reject } in request order
-        this._buffer = ''
-        this._proc.stdout.setEncoding('utf8')
-        this._proc.stdout.on('data', (chunk) => this._onData(chunk))
-        this._proc.on('exit', () => {
-            const err = new Error('fylo process exited')
-            for (const p of this._queue.splice(0)) p.reject(err)
-        })
-        // Surface spawn failures (e.g. binary missing) instead of crashing on an
-        // unhandled 'error' event.
-        this._proc.on('error', (err) => {
-            for (const p of this._queue.splice(0)) p.reject(err)
+        super({
+            name: 'fylo',
+            command: NdjsonProcessClient.resolveCommand('fylo', opts.binary),
+            args,
         })
         return new Proxy(this, FACADE)
     }
@@ -76,27 +67,6 @@ export class Fylo {
             restore: (id) => this.restoreDoc(name, id),
             find: (query) => this.findDocs(name, query)
         }
-    }
-
-    _onData(chunk) {
-        this._buffer += chunk
-        let nl
-        while ((nl = this._buffer.indexOf('\n')) !== -1) {
-            const line = this._buffer.slice(0, nl).trim()
-            this._buffer = this._buffer.slice(nl + 1)
-            if (!line) continue
-            const pending = this._queue.shift()
-            if (pending) pending.resolve(JSON.parse(line))
-        }
-    }
-
-    /** Send one raw machine-protocol op; resolves with the full response object. */
-    request(op) {
-        return new Promise((resolve, reject) => {
-            if (this._proc.exitCode !== null) return reject(new Error('fylo process exited'))
-            this._queue.push({ resolve, reject })
-            this._proc.stdin.write(JSON.stringify(op) + '\n')
-        })
     }
 
     /** Build an op, send it, and resolve with `result` (rejects on failure). */
@@ -196,12 +166,4 @@ export class Fylo {
         return this._op('importBulkData', { collection, url, limitOrOptions })
     }
 
-    /** Close stdin so the loop ends, and wait for the process to exit. */
-    close() {
-        return new Promise((resolve) => {
-            if (this._proc.exitCode !== null) return resolve()
-            this._proc.on('exit', () => resolve())
-            this._proc.stdin.end()
-        })
-    }
 }

--- a/src/vendor/shared/ndjson-process-client.mjs
+++ b/src/vendor/shared/ndjson-process-client.mjs
@@ -1,0 +1,202 @@
+// @ts-nocheck
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Owns one restartable subprocess that exchanges one JSON object per line.
+ * Protocol failures are terminal for the current process because continuing
+ * after a malformed response could associate later responses with wrong calls.
+ */
+export default class NdjsonProcessClient {
+    static _instances = new Set();
+
+    /**
+     * @param {{
+     *   name: string,
+     *   command: string,
+     *   args: string[],
+     *   spawnProcess?: typeof spawn,
+     * }} options
+     */
+    constructor(options) {
+        this._name = options.name;
+        this._command = options.command;
+        this._args = options.args;
+        this._spawnProcess = options.spawnProcess ?? spawn;
+        this._proc = null;
+        this._queue = [];
+        this._buffer = '';
+        this._closed = false;
+        this._needsRestart = false;
+        this._spawn();
+        NdjsonProcessClient._instances.add(this);
+    }
+
+    /** Close every live client owned by the current process. */
+    static async closeAll() {
+        const clients = [...NdjsonProcessClient._instances];
+        await Promise.allSettled(clients.map((client) => client.close()));
+    }
+
+    /** Prefer installed native binaries over package-manager command shims. */
+    static resolveCommand(command, explicit, env = process.env) {
+        if (explicit) return explicit;
+        const executableNames = process.platform === 'win32'
+            ? [`${command}.exe`, command]
+            : [command];
+        const candidates = [];
+        for (const directory of String(env.PATH ?? '').split(path.delimiter)) {
+            if (!directory) continue;
+            for (const executable of executableNames) {
+                const candidate = path.join(directory, executable);
+                if (existsSync(candidate)) candidates.push(candidate);
+            }
+        }
+        const native = candidates.find((candidate) => {
+            const normalized = candidate.replaceAll('\\', '/').toLowerCase();
+            return !normalized.includes('/node_modules/.bin/');
+        });
+        return native ?? command;
+    }
+
+    /** Keep sibling native helpers ahead of package-manager shims. */
+    static commandEnvironment(command, env = process.env) {
+        if (!path.isAbsolute(command)) return env;
+        const commandDirectory = path.dirname(command);
+        const directories = String(env.PATH ?? '')
+            .split(path.delimiter)
+            .filter((directory) => directory && path.resolve(directory) !== commandDirectory);
+        return {
+            ...env,
+            PATH: [commandDirectory, ...directories].join(path.delimiter),
+        };
+    }
+
+    _spawn() {
+        const proc = this._spawnProcess(this._command, this._args, {
+            stdio: ['pipe', 'pipe', 'inherit'],
+            env: NdjsonProcessClient.commandEnvironment(this._command),
+        });
+        if (!proc?.stdin || !proc?.stdout) {
+            throw new Error(`${this._name} process did not expose piped stdin/stdout`);
+        }
+        this._proc = proc;
+        this._buffer = '';
+        this._needsRestart = false;
+        proc.stdout.setEncoding('utf8');
+        proc.stdout.on('data', (chunk) => {
+            if (this._proc === proc) this._onData(String(chunk));
+        });
+        proc.stdout.on('end', () => {
+            if (this._proc === proc && this._queue.length > 0 && this._buffer.trim()) {
+                this._fail(new Error(`${this._name} emitted truncated NDJSON before stdout closed`));
+            }
+        });
+        proc.stdin.on('error', (error) => {
+            if (this._proc === proc) this._fail(this._ioError('stdin', error));
+        });
+        proc.on('error', (error) => {
+            if (this._proc === proc) this._fail(this._ioError('process', error));
+        });
+        proc.on('exit', (code, signal) => {
+            if (this._proc !== proc) return;
+            this._needsRestart = !this._closed;
+            const reason = code === null
+                ? `${this._name} process exited${signal ? ` from signal ${signal}` : ''}`
+                : `${this._name} process exited with code ${code}`;
+            this._rejectAll(new Error(reason));
+        });
+    }
+
+    /** @param {'stdin' | 'process'} source @param {unknown} error */
+    _ioError(source, error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        return new Error(`${this._name} ${source} failed: ${detail}`, { cause: error });
+    }
+
+    /** @param {string} chunk */
+    _onData(chunk) {
+        this._buffer += chunk;
+        let newline;
+        while ((newline = this._buffer.indexOf('\n')) !== -1) {
+            const line = this._buffer.slice(0, newline).trim();
+            this._buffer = this._buffer.slice(newline + 1);
+            if (!line) continue;
+            let response;
+            try {
+                response = JSON.parse(line);
+            }
+            catch (error) {
+                this._fail(new Error(`${this._name} emitted invalid NDJSON`, { cause: error }));
+                return;
+            }
+            const pending = this._queue.shift();
+            if (pending) pending.resolve(response);
+        }
+    }
+
+    /** @param {Error} error */
+    _fail(error) {
+        this._needsRestart = !this._closed;
+        this._rejectAll(error);
+        const proc = this._proc;
+        if (proc && proc.exitCode === null) {
+            try { proc.kill(); } catch { /* process already exited */ }
+        }
+    }
+
+    /** @param {Error} error */
+    _rejectAll(error) {
+        for (const pending of this._queue.splice(0)) pending.reject(error);
+    }
+
+    _activeProcess() {
+        if (this._closed) throw new Error(`${this._name} client is closed`);
+        if (!this._proc || this._needsRestart || this._proc.exitCode !== null) this._spawn();
+        return this._proc;
+    }
+
+    /** Send one request and resolve with its ordered NDJSON response. */
+    request(operation) {
+        let proc;
+        try {
+            proc = this._activeProcess();
+        }
+        catch (error) {
+            return Promise.reject(error);
+        }
+        return new Promise((resolve, reject) => {
+            this._queue.push({ resolve, reject });
+            try {
+                proc.stdin.write(`${JSON.stringify(operation)}\n`, (error) => {
+                    if (error && this._proc === proc) this._fail(this._ioError('stdin', error));
+                });
+            }
+            catch (error) {
+                this._fail(this._ioError('stdin', error));
+            }
+        });
+    }
+
+    /** Close stdin and wait for the active subprocess to exit. */
+    close() {
+        if (this._closed) return Promise.resolve();
+        this._closed = true;
+        NdjsonProcessClient._instances.delete(this);
+        this._needsRestart = false;
+        this._rejectAll(new Error(`${this._name} client closed before receiving a response`));
+        const proc = this._proc;
+        if (!proc || proc.exitCode !== null) return Promise.resolve();
+        return new Promise((resolve) => {
+            proc.once('exit', resolve);
+            try {
+                proc.stdin.end();
+            }
+            catch {
+                try { proc.kill(); } catch { /* process already exited */ }
+                resolve();
+            }
+        });
+    }
+}

--- a/tests/compiler/template-diagnostics.test.js
+++ b/tests/compiler/template-diagnostics.test.js
@@ -28,6 +28,12 @@ describe('malformed <loop>/<logic> directives fail the build instead of leaking 
         expect(await render('<logic :if="ok"><p>x</p></logic>')).toContain('if(ok)');
     });
 
+    test('a bare <logic else> compiles', async () => {
+        const output = await render('<logic :if="ok"><p>yes</p></logic><logic else><p>no</p></logic>');
+        expect(output).toContain('if(ok)');
+        expect(output).toContain('else {');
+    });
+
     test('<logic> with a typo\'d directive is a named error', async () => {
         await expect(render('<logic :iff="ok"><p>x</p></logic>'))
             .rejects.toThrow(/<logic>.*expected :if, :else-if, or else/s);

--- a/tests/integration/api-routes.test.js
+++ b/tests/integration/api-routes.test.js
@@ -199,34 +199,39 @@ async function authFetch(path, init = {}) {
  */
 async function waitForTelemetrySpans(requestId) {
     const fylo = new Fylo(telemetryRoot);
-    const startedAt = Date.now();
-    while (Date.now() - startedAt < 4_000) {
-        try {
-            /** @type {Array<{ resource: Record<string, any>, scope: Record<string, any>, span: Record<string, any> }>} */
-            const spans = [];
-            // Node shim find() resolves to an `{ id: doc }` map.
-            const found = /** @type {Record<string, any>} */ (await fylo['otel-spans'].find({}) ?? {});
-            for (const doc of Object.values(found)) {
-                spans.push(...extractPersistedSpans(/** @type {Record<string, any>} */ (doc)));
-                for (const traceDoc of Object.values(/** @type {Record<string, any>} */ (doc))) {
-                    if (traceDoc && typeof traceDoc === 'object') {
-                        spans.push(...extractPersistedSpans(/** @type {Record<string, any>} */ (traceDoc)));
+    try {
+        const startedAt = Date.now();
+        while (Date.now() - startedAt < 4_000) {
+            try {
+                /** @type {Array<{ resource: Record<string, any>, scope: Record<string, any>, span: Record<string, any> }>} */
+                const spans = [];
+                // Node shim find() resolves to an `{ id: doc }` map.
+                const found = /** @type {Record<string, any>} */ (await fylo['otel-spans'].find({}) ?? {});
+                for (const doc of Object.values(found)) {
+                    spans.push(...extractPersistedSpans(/** @type {Record<string, any>} */ (doc)));
+                    for (const traceDoc of Object.values(/** @type {Record<string, any>} */ (doc))) {
+                        if (traceDoc && typeof traceDoc === 'object') {
+                            spans.push(...extractPersistedSpans(/** @type {Record<string, any>} */ (traceDoc)));
+                        }
                     }
                 }
+                for (const doc of await readTelemetryDocsFromDisk()) {
+                    spans.push(...extractPersistedSpans(doc));
+                }
+                const matches = spans.filter((entry) => getAttribute(entry.span, 'tachyon.request.id') === requestId);
+                if (matches.length >= 2) {
+                    return matches;
+                }
+            } catch {
+                // Collection may not exist yet if the first span hasn't been written.
             }
-            for (const doc of await readTelemetryDocsFromDisk()) {
-                spans.push(...extractPersistedSpans(doc));
-            }
-            const matches = spans.filter((entry) => getAttribute(entry.span, 'tachyon.request.id') === requestId);
-            if (matches.length >= 2) {
-                return matches;
-            }
-        } catch {
-            // Collection may not exist yet if the first span hasn't been written.
+            await Bun.sleep(50);
         }
-        await Bun.sleep(50);
+        return [];
     }
-    return [];
+    finally {
+        await fylo.close();
+    }
 }
 
 async function readTelemetryDocsFromDisk() {
@@ -1810,11 +1815,15 @@ describe('FYLO_SCHEMA schema loading', () => {
         try {
             process.env.FYLO_SCHEMA = schemasDir;
             const fylo = new Fylo(root);
-
-            const inspect = await fylo[collection].inspect();
-            expect(inspect.exists).toBe(true);
-            expect(inspect.collection).toBe(collection);
-            expect(inspect.docsStored).toBe(0);
+            try {
+                const inspect = await fylo[collection].inspect();
+                expect(inspect.exists).toBe(true);
+                expect(inspect.collection).toBe(collection);
+                expect(inspect.docsStored).toBe(0);
+            }
+            finally {
+                await fylo.close();
+            }
         }
         finally {
             if (previousSchema === undefined) delete process.env.FYLO_SCHEMA;

--- a/tests/integration/bundle-static-export.test.js
+++ b/tests/integration/bundle-static-export.test.js
@@ -1407,11 +1407,7 @@ timedTest('spa prehydration skips malformed persisted fields without blocking va
     const prehydrateModulePath = path.join(root, 'prehydrate.js');
     await writeFile(prehydrateModulePath, runtimeSource
         .slice(0, prehydrateEnd)
-        .replace("import { cleanBooleanAttrs, createValueEventDetail, findEventTarget, morphChildren, parseFragment, parseParams, resolveHandler } from './dom-helpers.js';\n", '')
-        .replace("import { cacheModuleResponse, clearStaticCache, precacheModules } from './static-cache.js';\n", '')
-        .replace("import { createDeferredDelegation } from './event-hydration.js';\n", '')
-        .replace("import { createComponentRegistry } from './component-registry.js';\n", '')
-        .replace("import { ServiceWorkerPolicy } from './service-worker-policy.js';\n", ''));
+        .replace(/^import .*?;\n/gm, ''));
     const windowInstance = new Window();
     /** @type {Record<string, unknown>} */
     const previousGlobals = {

--- a/tests/integration/serve-full.test.js
+++ b/tests/integration/serve-full.test.js
@@ -53,11 +53,16 @@ document.documentElement.dataset.boot = bootMessage;
     }
     if (data) {
         const fylo = new Fylo(path.join(root, 'db'));
-        await fylo['users'].create();
-        await fylo['users'].put({
-            email: 'browser-db@example.test',
-            role: 'admin',
-        });
+        try {
+            await fylo['users'].create();
+            await fylo['users'].put({
+                email: 'browser-db@example.test',
+                role: 'admin',
+            });
+        }
+        finally {
+            await fylo.close();
+        }
     }
     return root;
 }

--- a/tests/integration/standalone-binary.test.js
+++ b/tests/integration/standalone-binary.test.js
@@ -1,0 +1,131 @@
+// @ts-check
+import { afterEach, expect, test } from 'bun:test';
+import { access, mkdtemp, readdir, rm } from 'fs/promises';
+import path from 'path';
+import { tmpdir } from 'os';
+
+const timedTest = /** @type {any} */ (test);
+/** @type {string[]} */
+const tempDirs = [];
+/** @type {Array<import('bun').Subprocess<'ignore' | 'pipe', 'ignore' | 'pipe', 'ignore' | 'pipe'>>} */
+const processes = [];
+
+/** @param {string} filePath */
+async function exists(filePath) {
+    try {
+        await access(filePath);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+
+/**
+ * @param {string[]} cmd
+ * @param {{ cwd?: string, env?: Record<string, string | undefined>, timeoutMs?: number }} [options]
+ */
+async function run(cmd, options = {}) {
+    const proc = Bun.spawn(cmd, {
+        cwd: options.cwd,
+        env: options.env,
+        stdout: 'pipe',
+        stderr: 'pipe',
+    });
+    const timeoutMs = options.timeoutMs ?? 60000;
+    const timeout = new Promise((_, reject) => {
+        setTimeout(() => reject(new Error(`Command timed out: ${cmd.join(' ')}`)), timeoutMs);
+    });
+    const [stdout, stderr, exitCode] = /** @type {Promise<[string, string, number]>} */ (await Promise.race([
+        Promise.all([
+            new Response(proc.stdout).text(),
+            new Response(proc.stderr).text(),
+            proc.exited,
+        ]),
+        timeout,
+    ]));
+    if (exitCode !== 0) {
+        throw new Error(`Command failed (${exitCode}): ${cmd.join(' ')}\n${stdout}\n${stderr}`);
+    }
+}
+
+/**
+ * @param {string} url
+ * @param {number} timeoutMs
+ */
+async function waitForHttp(url, timeoutMs = 15000) {
+    const deadline = Date.now() + timeoutMs;
+    let lastError = null;
+    while (Date.now() < deadline) {
+        try {
+            const response = await fetch(url);
+            if (response.ok)
+                return response;
+            lastError = new Error(`HTTP ${response.status}`);
+        }
+        catch (error) {
+            lastError = error;
+        }
+        await Bun.sleep(150);
+    }
+    throw lastError instanceof Error ? lastError : new Error(`Timed out waiting for ${url}`);
+}
+
+afterEach(async () => {
+    for (const proc of processes.splice(0)) {
+        proc.kill();
+        await proc.exited.catch(() => undefined);
+    }
+    for (const dir of tempDirs.splice(0)) {
+        await rm(dir, { recursive: true, force: true });
+    }
+});
+
+timedTest('compiled ty binary can init, bundle, and serve a client app', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'tachyon-standalone-'));
+    tempDirs.push(root);
+    const binaryPath = path.join(root, process.platform === 'win32' ? 'ty.exe' : 'ty');
+
+    await run(['bun', 'build', '--compile', path.join(process.cwd(), 'src/cli/index.js'), '--outfile', binaryPath], {
+        timeoutMs: 120000,
+    });
+    await run([binaryPath, 'init', 'smoke'], { cwd: root });
+
+    const appRoot = path.join(root, 'smoke');
+    const cacheRoot = path.join(root, 'cache');
+    const cacheEnv = { ...process.env, TACHYON_CACHE_DIR: cacheRoot };
+    await run([binaryPath, 'bundle', '--target', 'web'], { cwd: appRoot, env: cacheEnv, timeoutMs: 120000 });
+    expect(await exists(path.join(appRoot, 'dist', 'web', 'index.html'))).toBe(true);
+    expect(await exists(path.join(appRoot, 'dist', 'web', 'spa-renderer.js'))).toBe(true);
+    const cacheEntries = await readdir(path.join(cacheRoot, 'runtime'), { withFileTypes: true });
+    expect(cacheEntries.some((entry) => entry.isDirectory())).toBe(true);
+
+    await run([binaryPath, 'cache', 'clean'], { cwd: appRoot, env: cacheEnv });
+    expect(await exists(path.join(cacheRoot, 'runtime'))).toBe(false);
+
+    const port = String(18880 + Math.floor(Math.random() * 500));
+    const server = Bun.spawn([binaryPath, 'serve'], {
+        cwd: appRoot,
+        env: {
+            ...process.env,
+            TACHYON_CACHE_DIR: cacheRoot,
+            YON_HOST: '127.0.0.1',
+            YON_PORT: port,
+        },
+        stdout: 'pipe',
+        stderr: 'pipe',
+    });
+    processes.push(server);
+
+    const handlerResponse = await waitForHttp(`http://127.0.0.1:${port}/`);
+    expect(await handlerResponse.json()).toEqual({ ok: true, framework: 'Tachyon' });
+
+    const runtimeResponse = await waitForHttp(`http://127.0.0.1:${port}/spa-renderer.js`);
+    expect(runtimeResponse.headers.get('content-type')).toContain('text/javascript');
+    const runtimeSource = await runtimeResponse.text();
+    expect(runtimeSource).toContain('window.__tc_rerender');
+    expect(runtimeSource).not.toContain('__TACHYON_ASSET_PREFIX__');
+    expect(runtimeSource).not.toContain('__tachyonPlaceholder');
+    expect(runtimeSource).not.toContain('__tachyonShellPlaceholder');
+    expect(await exists(path.join(cacheRoot, 'runtime'))).toBe(true);
+}, 180000);

--- a/tests/runtime/duvay-events.test.js
+++ b/tests/runtime/duvay-events.test.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { afterAll, afterEach, beforeAll, expect, test } from 'bun:test';
 import { Window } from 'happy-dom';
-import { findEventTarget } from '../../src/runtime/dom-helpers.js';
+import { findEventTarget, findNavigationTarget } from '../../src/runtime/dom-helpers.js';
 
 /**
  * These tests prove Tac interoperates with Light-DOM web components (DuVay) via
@@ -112,4 +112,12 @@ test('arbitrary custom event names delegate the same way (no allow-list)', () =>
     const cleared = delegate('clear');
     host.dispatchEvent(new CustomEvent('clear', { bubbles: true, composed: true }));
     expect(cleared.hits).toEqual([host]);
+});
+
+test('an href-bearing web component is a client-navigation target', () => {
+    document.body.innerHTML = `<w-btn id="atlas" href="/atlas">Atlas</w-btn>`;
+    const button = /** @type {Element} */ (document.getElementById('atlas'));
+    const event = new windowInstance.Event('click', { bubbles: true, composed: true });
+    button.dispatchEvent(/** @type {any} */ (event));
+    expect(findNavigationTarget(event)).toBe(button);
 });

--- a/tests/runtime/event-hydration.test.js
+++ b/tests/runtime/event-hydration.test.js
@@ -157,6 +157,13 @@ describe('EVENT_CAPTURE_SCRIPT (pre-hydration dead-zone capture)', () => {
         expect(capture().queue).toEqual([{ type: 'click', target: document.getElementById('a') }]);
     });
 
+    test('records a click on an href-bearing web component (for SPA-nav replay)', () => {
+        document.body.innerHTML = `<w-btn id="docs" href="/docs">Docs</w-btn>`;
+        const button = /** @type {Element} */ (document.getElementById('docs'));
+        button.dispatchEvent(/** @type {any} */ (new windowInstance.Event('click', { bubbles: true, cancelable: true })));
+        expect(capture().queue).toEqual([{ type: 'click', target: button }]);
+    });
+
     test('ignores clicks that do not target a Tac handler', () => {
         document.body.innerHTML = `<div id="plain">nothing</div>`;
         const plain = /** @type {Element} */ (document.getElementById('plain'));

--- a/tests/server/ndjson-process-client.test.js
+++ b/tests/server/ndjson-process-client.test.js
@@ -1,0 +1,158 @@
+// @ts-check
+import { expect, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
+import { mkdir, mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import NdjsonProcessClient from '../../src/vendor/shared/ndjson-process-client.mjs';
+
+class FakePipe extends EventEmitter {
+    /** @type {Error | null} */
+    writeError = null;
+    writableEnded = false;
+
+    setEncoding() { }
+    ref() { }
+    unref() { }
+
+    /** @param {string} _chunk @param {(error?: Error | null) => void} [callback] */
+    write(_chunk, callback) {
+        queueMicrotask(() => callback?.(this.writeError));
+        return !this.writeError;
+    }
+
+    end() {
+        this.writableEnded = true;
+    }
+}
+
+class FakeProcess extends EventEmitter {
+    stdin = new FakePipe();
+    stdout = new FakePipe();
+    exitCode = null;
+    killed = false;
+
+    constructor() {
+        super();
+        const end = this.stdin.end.bind(this.stdin);
+        this.stdin.end = () => {
+            end();
+            queueMicrotask(() => {
+                if (this.exitCode === null) {
+                    this.exitCode = 0;
+                    this.emit('exit', 0, null);
+                }
+            });
+        };
+    }
+
+    ref() { }
+    unref() { }
+
+    kill() {
+        this.killed = true;
+        this.exitCode = 1;
+        this.emit('exit', 1, null);
+    }
+}
+
+test('native vendor binaries take precedence over node_modules command shims', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'tachyon-vendor-command-'));
+    const packageBin = path.join(root, 'node_modules', '.bin');
+    const nativeBin = path.join(root, '.local', 'bin');
+    const executable = process.platform === 'win32' ? 'fylo.exe' : 'fylo';
+    await mkdir(packageBin, { recursive: true });
+    await mkdir(nativeBin, { recursive: true });
+    await writeFile(path.join(packageBin, executable), 'package shim');
+    await writeFile(path.join(nativeBin, executable), 'native binary');
+
+    try {
+        expect(NdjsonProcessClient.resolveCommand('fylo', undefined, {
+            PATH: `${packageBin}${path.delimiter}${nativeBin}`,
+        })).toBe(path.join(nativeBin, executable));
+    }
+    finally {
+        await rm(root, { recursive: true, force: true });
+    }
+});
+
+test('native subprocesses prioritize sibling helper binaries', () => {
+    const command = path.resolve('/native/bin/fylo');
+    const packageBin = path.resolve('/workspace/node_modules/.bin');
+    const env = NdjsonProcessClient.commandEnvironment(command, {
+        PATH: `${packageBin}${path.delimiter}${path.dirname(command)}`,
+    });
+    expect(env.PATH?.split(path.delimiter)).toEqual([
+        path.dirname(command),
+        packageBin,
+    ]);
+});
+
+test('malformed NDJSON rejects the request and a later request uses a fresh process', async () => {
+    const first = new FakeProcess();
+    const second = new FakeProcess();
+    const processes = [first, second];
+    const client = new NdjsonProcessClient({
+        name: 'fylo',
+        command: 'fylo',
+        args: ['exec', '--loop'],
+        spawnProcess: () => processes.shift(),
+    });
+
+    const malformed = client.request({ op: 'inspectCollection' });
+    first.stdout.emit('data', '{"ok":tru\n');
+    await expect(malformed).rejects.toThrow('fylo emitted invalid NDJSON');
+    expect(first.killed).toBe(true);
+
+    const recovered = client.request({ op: 'inspectCollection' });
+    second.stdout.emit('data', '{"ok":true,"result":{"exists":true}}\n');
+    await expect(recovered).resolves.toEqual({ ok: true, result: { exists: true } });
+    expect(client._proc).toBe(second);
+    await client.close();
+});
+
+test('stdin EPIPE rejects every pending request without an unhandled stream error', async () => {
+    const process = new FakeProcess();
+    process.stdin.writeError = Object.assign(new Error('broken pipe'), { code: 'EPIPE' });
+    const client = new NdjsonProcessClient({
+        name: 'chex',
+        command: 'chex',
+        args: ['exec', '--loop'],
+        spawnProcess: () => process,
+    });
+
+    const first = client.request({ op: 'validate' });
+    const second = client.request({ op: 'validate' });
+    const outcomes = await Promise.allSettled([first, second]);
+    expect(outcomes.every((outcome) => outcome.status === 'rejected')).toBe(true);
+    for (const outcome of outcomes) {
+        if (outcome.status === 'rejected') {
+            expect(outcome.reason).toBeInstanceOf(Error);
+            expect(outcome.reason.message).toBe('chex stdin failed: broken pipe');
+        }
+    }
+    expect(process.killed).toBe(true);
+    await client.close();
+});
+
+test('an exited subprocess rejects pending work and is restarted on the next request', async () => {
+    const first = new FakeProcess();
+    const second = new FakeProcess();
+    const processes = [first, second];
+    const client = new NdjsonProcessClient({
+        name: 'fylo',
+        command: 'fylo',
+        args: ['exec', '--loop'],
+        spawnProcess: () => processes.shift(),
+    });
+
+    const interrupted = client.request({ op: 'findDocs' });
+    first.exitCode = 9;
+    first.emit('exit', 9, null);
+    await expect(interrupted).rejects.toThrow('fylo process exited with code 9');
+
+    const recovered = client.request({ op: 'findDocs' });
+    second.stdout.emit('data', '{"ok":true,"result":{}}\n');
+    await expect(recovered).resolves.toEqual({ ok: true, result: {} });
+    await client.close();
+});

--- a/tests/server/yon-js-runner.test.js
+++ b/tests/server/yon-js-runner.test.js
@@ -1,0 +1,66 @@
+// @ts-check
+import { expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import { pathToFileURL } from 'url';
+
+const RUNNER = path.join(import.meta.dir, '../../src/server/process/adapters/yon-js-runner.js');
+const PROCESS_CLIENT = path.join(import.meta.dir, '../../src/vendor/shared/ndjson-process-client.mjs');
+
+test('JavaScript handlers close persistent NDJSON clients before the runner exits', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'tachyon-yon-js-runner-'));
+    const helper = path.join(root, 'ndjson-helper.js');
+    const handler = path.join(root, 'yon.js');
+    await Bun.write(helper, `
+let buffer = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', (chunk) => {
+  buffer += chunk;
+  let newline;
+  while ((newline = buffer.indexOf('\\n')) !== -1) {
+    buffer = buffer.slice(newline + 1);
+    process.stdout.write('{"ok":true,"result":{"ready":true}}\\n');
+  }
+});
+setTimeout(() => process.exit(0), 5000).unref();
+`);
+    await Bun.write(handler, `
+import NdjsonProcessClient from ${JSON.stringify(pathToFileURL(PROCESS_CLIENT).href)};
+
+export class Handler {
+  static async GET() {
+    const client = new NdjsonProcessClient({
+      name: 'fixture',
+      command: process.execPath,
+      args: [${JSON.stringify(helper)}],
+    });
+    await client.request({ op: 'ready' });
+    return { ok: true };
+  }
+}
+`);
+
+    const proc = Bun.spawn([process.execPath, RUNNER, handler], {
+        stdin: 'pipe',
+        stdout: 'pipe',
+        stderr: 'pipe',
+    });
+    proc.stdin.write(JSON.stringify({ method: 'GET' }));
+    proc.stdin.end();
+
+    try {
+        const exitedPromptly = await Promise.race([
+            proc.exited.then(() => true),
+            Bun.sleep(1_500).then(() => false),
+        ]);
+        expect(exitedPromptly).toBe(true);
+        expect(await new Response(proc.stdout).text()).toContain('{"ok":true}');
+        expect(await new Response(proc.stderr).text()).toBe('');
+    }
+    finally {
+        if (proc.exitCode === null) proc.kill();
+        await proc.exited.catch(() => { });
+        await rm(root, { recursive: true, force: true });
+    }
+});

--- a/tests/shared/runtime-cache.test.js
+++ b/tests/shared/runtime-cache.test.js
@@ -1,0 +1,57 @@
+// @ts-check
+import { afterEach, expect, test } from 'bun:test';
+import { access, mkdtemp, readFile, rm, unlink } from 'fs/promises';
+import { tmpdir } from 'os';
+import path from 'path';
+import TachyonRuntimeCache from '../../src/shared/runtime-cache.js';
+
+/** @type {string[]} */
+const roots = [];
+const previousCacheDir = process.env.TACHYON_CACHE_DIR;
+
+afterEach(async () => {
+    if (previousCacheDir === undefined)
+        delete process.env.TACHYON_CACHE_DIR;
+    else
+        process.env.TACHYON_CACHE_DIR = previousCacheDir;
+    for (const root of roots.splice(0))
+        await rm(root, { recursive: true, force: true });
+});
+
+/** @param {string} filePath */
+async function exists(filePath) {
+    try {
+        await access(filePath);
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+
+test('materializes, validates, repairs, and clears the standalone runtime cache', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'tachyon-runtime-cache-'));
+    roots.push(root);
+    process.env.TACHYON_CACHE_DIR = root;
+    const files = [
+        { path: 'runtime/example.js', source: 'export const answer = 42;\n' },
+        { path: 'runtime/nested/helper.js', source: 'export const helper = true;\n' },
+    ];
+
+    const [cachedRoot, concurrentRoot] = await Promise.all([
+        TachyonRuntimeCache.materialize(files),
+        TachyonRuntimeCache.materialize(files),
+    ]);
+    expect(concurrentRoot).toBe(cachedRoot);
+    expect(cachedRoot.startsWith(path.join(root, 'runtime'))).toBe(true);
+    expect(await readFile(path.join(cachedRoot, 'runtime/example.js'), 'utf8')).toBe(files[0].source);
+    expect(JSON.parse(await readFile(path.join(cachedRoot, 'manifest.json'), 'utf8')).files).toHaveLength(2);
+
+    await unlink(path.join(cachedRoot, 'runtime/example.js'));
+    const repairedRoot = await TachyonRuntimeCache.materialize(files);
+    expect(repairedRoot).toBe(cachedRoot);
+    expect(await readFile(path.join(repairedRoot, 'runtime/example.js'), 'utf8')).toBe(files[0].source);
+
+    await TachyonRuntimeCache.clear();
+    expect(await exists(path.join(root, 'runtime'))).toBe(false);
+});

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tac-h-yon",
-  "version": "26.28.04",
+  "version": "26.28.05",
   "private": true,
   "type": "module",
   "displayName": "Tachyon",


### PR DESCRIPTION
## Summary
- repair standalone `ty bundle` and `ty serve` execution with embedded runtime source caching
- harden Tac navigation/event hydration and documented bare `<logic else>` compilation
- make FYLO/CHEX NDJSON clients restartable, lifecycle-safe, and native-binary-first
- bump framework and website metadata to `26.28.05`

## Verification
- `bun run typecheck`
- `bun run test` (530 passed)
- website DOM suite (20 passed)
- macOS standalone binary compile, version/help/cache smoke
- Linux x64 standalone cross-compile
- `bun audit --production` (no vulnerabilities)

Closes #104