### PR TITLE
Fix mobile website touch targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,9 @@ independent major versions.
 
 ### Fixed
 
+- Kept the website's mobile navigation, brand link, language controls, and
+  footer links at the 44-pixel touch-target minimum, removed a nested
+  interactive chip from the home link, and respected the bottom safe area.
 - Made release archives deterministic under both GNU tar and BSD tar by
   normalizing staged file timestamps before archiving.
 - Made Windows upgrades download and verify into a same-directory temporary

--- a/website/client/components/site/footer/tac.css
+++ b/website/client/components/site/footer/tac.css
@@ -15,9 +15,19 @@
 }
 
 .footer-links a {
+  display: inline-flex;
+  align-items: center;
+  min-width: var(--w-touch-min);
+  min-height: var(--w-touch-min);
   color: var(--w-text-subtle);
   text-decoration: none;
   font-size: var(--w-font-sm);
+}
+
+@supports (padding: env(safe-area-inset-bottom)) {
+  .footer-inner {
+    padding-bottom: calc(1.5rem + env(safe-area-inset-bottom));
+  }
 }
 
 .footer-links a:hover {

--- a/website/client/components/site/header/tac.css
+++ b/website/client/components/site/header/tac.css
@@ -11,6 +11,23 @@ a {
   font-size: 0.95rem;
 }
 
+.brand-tag {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.25rem;
+  padding-inline: 0.5rem;
+  border-radius: var(--w-radius-pill);
+  background: var(--w-success-container);
+  color: var(--w-on-success-container);
+  font-size: var(--w-font-xs);
+  font-weight: var(--w-font-weight-medium);
+  line-height: 1;
+}
+
+.site-header-row > a[aria-label="Tachyon home"] {
+  min-height: var(--w-touch-min);
+}
+
 .header-burger {
   border: 1px solid color-mix(in srgb, var(--w-text) 12%, transparent);
   border-radius: calc(var(--w-radius) + 0.625rem);

--- a/website/client/components/site/header/tac.html
+++ b/website/client/components/site/header/tac.html
@@ -3,7 +3,7 @@
     <a href="/" class="w-row align-center ga-2 mr-auto" aria-label="Tachyon home">
       <img class="brand-mark" src="/shared/assets/logo.svg" alt="" width="28" height="28" />
       <span class="brand-name">TACHYON</span>
-      <w-chip size="x-small" color="success">Tac + Yon</w-chip>
+      <span class="brand-tag">Tac + Yon</span>
     </a>
 
     <nav class="w-row align-center ga-1 only-desktop" aria-label="Primary navigation">

--- a/website/client/shared/styles/site.css
+++ b/website/client/shared/styles/site.css
@@ -124,9 +124,14 @@ w-app-bar {
   }
 
   /* Comfortable tap targets — keyed to viewport width, not device type. */
-  .w-btn,
-  button {
-    min-height: 44px;
+  .w-btn.w-btn,
+  button.w-chip {
+    min-width: var(--w-touch-min);
+    min-height: var(--w-touch-min);
+  }
+
+  a[aria-label="Tachyon home"] {
+    min-height: var(--w-touch-min);
   }
 }
 

--- a/website/tests/dom/site.dom.test.js
+++ b/website/tests/dom/site.dom.test.js
@@ -64,6 +64,23 @@ describe('homepage DOM', () => {
         expect(home.document.querySelector('w-bottom-navigation')).toBeFalsy()
         expect(home.document.querySelector('w-footer')).toBeTruthy()
         expect(home.document.querySelector('img.brand-mark[src="/shared/assets/logo.svg"]')).toBeTruthy()
+        expect(home.document.querySelector('a[aria-label="Tachyon home"] .brand-tag')?.textContent).toBe('Tac + Yon')
+        expect(home.document.querySelector('a[aria-label="Tachyon home"] w-chip')).toBeFalsy()
+    })
+
+    test('keeps mobile controls and footer links at the product touch-target minimum', async () => {
+        const site = await read('client/shared/styles/site.css')
+        const header = await read('client/components/site/header/tac.css')
+        const footer = await read('client/components/site/footer/tac.css')
+
+        expect(site).toContain('.w-btn.w-btn,\n  button.w-chip {')
+        expect(site).toContain('min-width: var(--w-touch-min);')
+        expect(site).toContain('min-height: var(--w-touch-min);')
+        expect(site).toContain('a[aria-label="Tachyon home"] {')
+        expect(header).toContain('.site-header-row > a[aria-label="Tachyon home"]')
+        expect(footer).toContain('.footer-links a {\n  display: inline-flex;')
+        expect(footer).toContain('min-width: var(--w-touch-min);')
+        expect(footer).toContain('env(safe-area-inset-bottom)')
     })
 
     test('renders the hero and feature cards', () => {


### PR DESCRIPTION
## What changed

- remove the nested interactive chip from the Tachyon home link while preserving its visual treatment
- enforce the 44px touch-target minimum for mobile navigation controls, the home link, and footer links
- add bottom safe-area padding to the footer
- add DOM regressions and document the fix in the 26.31.06 changelog

## Why

The release UX audit found undersized mobile targets and a button-like custom element nested inside the home anchor. Those violate the release accessibility baseline and make touch interaction less reliable.

## Impact

No runtime, compiler, server, API, dependency, or permission behavior changes. The website gains larger mobile hit areas and valid interactive semantics.

## Validation

- Codebase Steward and UX browser audits (390×844 and 1440×900)
- 25 website tests / 170 expectations
- TypeScript typecheck
- canonical Rust fmt/check/clippy/test/doc/cargo-deny gate
- browser, events, offline, islands, WebAssembly ABI and five-language companion suites
- parity ledger (31/31)
- v26.30.04 compatibility differential (3/3) and standalone workflow
- macOS native acceptance
- reproducible release lifecycle and artifact checks

## Release note

This PR remains draft until exact-head CI and PR feedback are complete. Stable tag/publication remains independently blocked by the documented named human security review requirement.
