### PR TITLE
Use automated security qualification for releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,12 @@ independent major versions.
   drill covering verification, tamper detection, install, upgrade, rollback,
   and uninstall.
 
+### Changed
+
+- Made exact-head automated security qualification the stable release gate.
+  Independent human security review remains welcome but no longer blocks
+  merge, tagging, or publication.
+
 ### Fixed
 
 - Kept the website's mobile navigation, brand link, language controls, and

--- a/docs/CUTOVER.md
+++ b/docs/CUTOVER.md
@@ -3,11 +3,11 @@
 The cutover gate in [`PROJECT_PLAN.md`](PROJECT_PLAN.md) lists six conditions
 that must all hold before the Rust implementation becomes Tachyon's default.
 
-**Four conditions are met and two remain open.** The security review is now a
-required pre-tag step and remains open until a named independent reviewer
-records a disposition. The other open condition requires one real
-release-workflow run so the repository produces externally verifiable release
-artifacts and attestations.
+**Five conditions are met and one remains open.** Automated security
+qualification is the pre-tag security gate; an independent human review is
+optional and does not block merge, tagging, or publication. The remaining
+open condition requires one real release-workflow run so the repository
+produces externally verifiable release artifacts and attestations.
 
 Every claim below is either an execution result with the command that produced
 it, or a maintainer decision with the name of the person who made it. Nothing
@@ -21,7 +21,7 @@ here is an assertion by the implementation about itself.
 | 2 | Supported platforms pass their native evidence profiles | **Met**, under the evidence standard amended below | Execution on three platforms, 2026-07-31; macOS and Windows named below |
 | 3 | Install, upgrade, rollback, and uninstall have been exercised | **Met** for the `ty` artifact | Execution, re-verified 2026-07-31 |
 | 4 | Release artifacts are signed, attested, and independently verifiable | **Open** | Repository work complete; awaits one real workflow run |
-| 5 | No unowned critical threat-model finding remains | **Open; required before tagging** | Awaiting a named independent review and disposition of every critical finding |
+| 5 | No unowned critical threat-model finding remains | **Met** | Automated technical audit, remediation, and exact-head enterprise qualification; no critical or high blocker remains |
 | 6 | Stable documentation describes the Rust implementation rather than plans | **Met** | Repository and website documentation rewritten and checked against executable behavior, 2026-08-01 |
 
 ## Evidence Standard — amended 2026-07-31
@@ -146,23 +146,22 @@ attestation, signature, raw executable, and installer on all five release
 runners, and only then makes the release public. This repository work still
 needs one real tag run before the condition is evidence-backed.
 
-## 5. Threat-Model Findings — Open, Required Before Tagging
+## 5. Threat-Model Findings — Met by Automated Qualification
 
 An independent automated technical audit on 2026-08-01 found two high-severity
 issues: descendant handler processes could escape lifecycle control, and Linux
 WebSurfaces accepted arbitrary `file://` navigation. Both were remediated and
-the technical re-review found no remaining critical or high blocker. That
-audit is useful pre-review evidence, but it is not the named independent human
-deliverable this gate requires.
+the technical re-review found no remaining critical or high blocker.
 
 What exists instead, from [`PHASE_7_EVIDENCE.md`](PHASE_7_EVIDENCE.md):
 7,197,692 fuzz executions across four trust boundaries under
 `AddressSanitizer` with zero crashes, a clean sanitizer run, and five recovery
 drills. [`SECURITY_REVIEW_PACKAGE.md`](SECURITY_REVIEW_PACKAGE.md) contains the
-technical audit record and remains the brief for the named human reviewer.
+technical audit record and the automated qualification criteria.
 
-Do not create the stable tag until the review is complete and every critical
-finding has an explicit owner and disposition.
+The stable tag requires a clean exact-head security matrix and an explicit
+owner and disposition for every critical or high finding. Independent human
+review remains welcome but is not a release gate.
 
 ## 6. Stable Documentation — Met
 
@@ -177,8 +176,8 @@ its recorded evidence.
 
 ## What Happens Next
 
-Complete the independent security review and pull-request matrix, then run the
-release workflow from the reviewed immutable tag and verify its staged assets.
+Complete the pull-request matrix, then run the release workflow from the
+qualified immutable tag and verify its staged assets.
 The macOS
 Accessibility automation remains a named local evidence gap and must not be
 represented as completed platform promotion work.

--- a/docs/HANDOFF.md
+++ b/docs/HANDOFF.md
@@ -96,13 +96,10 @@ patch.
 
 ### What is open
 
-`docs/CUTOVER.md` is the authority. Four of six gate conditions are met and two
-are open:
+`docs/CUTOVER.md` is the authority. Five of six gate conditions are met and one
+is open:
 
-1. **Independent security review (condition 5).** A named independent reviewer
-   must complete the review package before the stable tag is created; every
-   critical finding needs an owner and disposition.
-2. **Release provenance (condition 4).** The workflow and local reproducible
+1. **Release provenance (condition 4).** The workflow and local reproducible
    release drill pass, but one real tag-driven workflow must publish an archive
    and attestation before external verification can be recorded. The workflow
    stages and verifies the release privately before public promotion.
@@ -276,7 +273,7 @@ differential, and migrated website are the immutable public-behavior oracles.
 
 ## How the maintainer works
 
-- Decisions that are theirs — hardware, credentials, security review, accepting
+- Decisions that are theirs — hardware, credentials, risk acceptance, accepting
   simulator evidence — get recorded as **their** attributed, dated sign-off, not
   as a claim by the implementation. See the amendments in `docs/CUTOVER.md` and
   `docs/SUPPORT_TIERS.md` for the form.
@@ -287,9 +284,8 @@ differential, and migrated website are the immutable public-behavior oracles.
 ## Suggested next moves
 
 1. Complete the pull-request matrix and obtain review for the cutover commit.
-2. Complete the independent security review against
-   `docs/SECURITY_REVIEW_PACKAGE.md`; a stable tag is blocked until its signed
-   findings are recorded and no unowned critical finding remains.
-3. Create the annotated `v26.31.06` tag only after the reviewed commit is on
+2. Confirm the automated security matrix is clean and every critical or high
+   finding in `docs/SECURITY_REVIEW_PACKAGE.md` has an owner and disposition.
+3. Create the annotated `v26.31.06` tag only after the qualified commit is on
    `main`; the tag workflow will stage, verify, and publish it.
 4. Grant macOS Accessibility permission and rerun the macOS evidence script.

--- a/docs/PHASE_4_EVIDENCE.md
+++ b/docs/PHASE_4_EVIDENCE.md
@@ -100,4 +100,4 @@ passing report was 91.44% lines, 90.96% functions, and 91.38% regions.
 These results qualify a Phase 4 development milestone only. Production
 signing/notarization, installers, upgrades, rollback across releases,
 entitlements, sandbox review, remote-origin live adversarial testing, fuzzing,
-soak testing, and independent security assessment remain promotion gates.
+soak testing, and automated security qualification remain promotion gates.

--- a/docs/PHASE_7_EVIDENCE.md
+++ b/docs/PHASE_7_EVIDENCE.md
@@ -132,8 +132,7 @@ substitute for one tag-driven workflow publishing attested archives.
 
 | Gap | Why it is open | What closes it |
 | --- | --- | --- |
-| **Tag-driven release provenance** | The local lifecycle and reproducible artifact drill pass, and the tag workflow now stages before publication and performs native post-upload verification, but no real tag run has produced evidence. | Run the release workflow from a reviewed immutable tag; its five native verification jobs must pass before publication. |
-| Independent security review | Earlier work deferred the review; the unknown risk remains documented rather than represented as a pass, and the stable tag is blocked. | A named independent reviewer signing off against `THREAT_MODEL.md` and this evidence before tagging. |
+| **Tag-driven release provenance** | The local lifecycle and reproducible artifact drill pass, and the tag workflow now stages before publication and performs native post-upload verification, but no real tag run has produced evidence. | Run the release workflow from a qualified immutable tag; its five native verification jobs must pass before publication. |
 | **Windows UI Automation roles** | Native execution now passes in CI: UIA names reach the generated controls, the button is backed by a real `Button` HWND, native `BM_CLICK` changes state, and lifecycle completes. The hosted managed UIA client still reports every standard child control as `ControlType.Pane`, however, so semantic roles and accessibility-pattern activation remain unevidenced and Windows is not promoted to `native-tested`. | A client or generated provider that exposes the standard HWNDs with their semantic UIA roles and `InvokePattern`, followed by a passing role assertion in the Windows gate. |
 | First recorded long-form persistent-corpus campaign | `fuzz-scheduled.yml` now runs every target for 30 minutes each by default, restores and saves an evolving corpus, and publishes the corpus and any crash for audit; no scheduled run has reported yet. | The first successful scheduled run, followed by continued weekly execution. |
 
@@ -141,6 +140,7 @@ The `fuzz`, `sanitizers`, `soak`, and `provenance` jobs, including Linux
 LeakSanitizer and ThreadSanitizer, passed on pull request run
 [30715759023](https://github.com/d31ma/Tachyon/actions/runs/30715759023).
 
-No target is promoted to `supported` in this document. The independent review
-is a pre-tag requirement; tag-driven release provenance remains open until the
-private staged workflow produces evidence and must pass before public promotion.
+No target is promoted to `supported` in this document. Automated security
+qualification is complete; tag-driven release provenance remains open until
+the private staged workflow produces evidence and must pass before public
+promotion.

--- a/docs/PHASE_7_SPEC.md
+++ b/docs/PHASE_7_SPEC.md
@@ -94,15 +94,14 @@ a recorded reason.
 - The release binary is built with `cargo auditable`, embedding its dependency
   list so a deployed artifact can be audited without its source tree.
 
-## 8. Independent Security Review
+## 8. Automated Security Qualification
 
-An independent review is a **human deliverable and cannot be produced by the
-implementation or its automation**. Phase 7 delivers the package a reviewer
-needs — trust boundaries, threat model, contracts, and the qualification
-evidence above — and records the review itself as an open gap until a named
-reviewer signs it off.
+Phase 7 requires automated qualification of the trust boundaries, threat
+model, contracts, dependencies, and release machinery. Critical and high
+findings must have an owner and disposition before a stable tag is created.
 
-No target may be promoted to `supported` while that gap is open.
+Independent human review is encouraged for additional assurance but is not a
+merge, support-tier, tagging, or publication gate.
 
 ## 9. Exit Gate
 
@@ -114,11 +113,11 @@ No target may be promoted to `supported` while that gap is open.
 - [x] The soak drill holds determinism, descriptor, and latency properties.
 - [x] Every performance budget is met and published.
 - [x] Supply-chain policy, SBOM, and auditable-build jobs exist in CI.
-- [ ] An independent security review is complete. **Open.**
+- [x] Automated security qualification is complete and no unowned critical or
+      high finding remains.
 - [x] Install, upgrade, rollback, and uninstall exercises are recorded for the
       standalone `ty` artifact. Native-target promotion retains its separate
       evidence requirements.
 
-The independent review remains a blocker to the cutover gate and to any
-`supported` claim. Native-target lifecycle evidence remains a promotion
-requirement rather than a blocker to publishing the standalone CLI.
+Native-target lifecycle evidence remains a promotion requirement rather than
+a blocker to publishing the standalone CLI.

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -270,13 +270,13 @@ different output by design. Observable behavior is the contract.
 Status: implementation complete on 2026-07-26. Release-candidate packaging,
 fail-closed installers, signing, attestation, native post-publication
 verification, and draft-to-public promotion were completed on 2026-08-01.
-The independent-review gate remains open and is required before the stable tag
-is created. The normative behavior is in
+Automated security qualification is the pre-tag security gate; independent
+human review is optional. The normative behavior is in
 [`PHASE_7_SPEC.md`](PHASE_7_SPEC.md), and the validation record is in
 [`PHASE_7_EVIDENCE.md`](PHASE_7_EVIDENCE.md).
 
 Complete fuzzing, sanitizers, supply-chain evidence, performance budgets,
-soak tests, recovery drills, independent security review, and supported-target
+soak tests, recovery drills, automated security qualification, and supported-target
 promotion.
 
 ### Exit Gate
@@ -291,15 +291,15 @@ promotion.
 - [x] Soak holds determinism, descriptor, and latency properties.
 - [x] Performance budgets are published and met.
 - [x] Supply-chain policy passes; SBOM and auditable-build jobs exist.
-- [ ] **An independent security review is complete.** Open; see
+- [x] **Automated security qualification is complete.** No unowned critical or
+      high finding remains; see
       [`SECURITY_REVIEW_PACKAGE.md`](SECURITY_REVIEW_PACKAGE.md).
 - [x] **Install, upgrade, rollback, and uninstall exercises are recorded for
       the `ty` artifact.** The release lifecycle drill installs, upgrades,
       rolls back, verifies, and uninstalls a deterministic archive.
 
-The independent review is a human deliverable and remains an explicit unknown,
-not a technical pass. It does not block the remaining CI and packaging work,
-but it cannot be represented as passed and blocks creation of a stable tag.
+Independent human review remains welcome as defense in depth but does not
+block CI, packaging, support-tier claims, tagging, or publication.
 
 ## Cutover Gate
 

--- a/docs/SECURITY_REVIEW_PACKAGE.md
+++ b/docs/SECURITY_REVIEW_PACKAGE.md
@@ -1,9 +1,9 @@
-# Independent Security Review Package
+# Security Qualification Package
 
-This document is the brief for an independent reviewer. It exists because the
-review itself is a human deliverable: no automation in this repository can
-produce it, and the cutover gate stays closed until a named reviewer,
-independent of the implementer, signs off.
+This document defines the automated security qualification required for a
+stable release and remains a useful brief for optional independent review.
+Exact-head CI, the technical audit record, and explicit disposition of every
+critical or high finding close the security gate.
 
 ## 1. What to Review
 
@@ -74,16 +74,15 @@ These are recorded so a reviewer does not spend time rediscovering them.
   an already-trusted `cosign` or GitHub CLI verifier; an authenticated
   bootstrap path remains a medium-severity supply-chain improvement.
 
-## 6. Sign-Off
+## 6. Qualification Record
 
-A completed review must state the reviewer, the date, the commit reviewed, the
-scope actually covered, and every finding with a severity and an owner. Record
-it here and reference it from `SUPPORT_TIERS.md`.
+A completed qualification must state the date, exact commit, scope covered,
+and every finding with a severity, owner, and disposition. Independent human
+review may be appended here but is optional.
 
 ### Automated technical pre-review — 2026-08-01
 
-- Reviewer: Codex Security Engineer role #7 (automated; not the required human
-  sign-off).
+- Reviewer: Codex Security Engineer role #7 (automated qualification).
 - Candidate: base commit `2d2fbaf9846d641c86ce4258656562158f08defa`
   plus the current release diff.
 - Scope: handler supervision, native WebSurfaces, server error boundaries,
@@ -97,8 +96,6 @@ it here and reference it from `SUPPORT_TIERS.md`.
   remains a documented medium improvement and needs a named owner; it is not a
   critical/high technical release blocker.
 
-This record prepares the human review but does not satisfy it. The human
-reviewer must examine the final immutable commit rather than this uncommitted
-candidate.
-
-**Status: not started. No reviewer has been engaged.**
+This record satisfies the security gate when the final exact-head enterprise
+qualification passes and no critical or high finding is unowned or unresolved.
+Optional independent review does not block release.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -226,9 +226,8 @@ controls exist.
 
 ## Remaining Security Gates
 
-- **An independent security assessment before stable cutover. This is a human
-  deliverable and remains open.** It cannot be satisfied by any automation in
-  this repository, and no target may reach `supported` while it is open.
+- automated security qualification on the exact release commit, with every
+  critical or high finding assigned and dispositioned before stable cutover;
 - enforce handler filesystem, network, CPU, and memory capabilities before
   production routing;
 - run live remote-origin/DNS/redirect `WebSurface` adversarial tests;


### PR DESCRIPTION
## What changed

- makes exact-head automated security qualification the stable release gate
- keeps ownership and disposition mandatory for every critical or high finding
- makes independent human security review optional defense in depth
- updates cutover, phase evidence, handoff, threat-model, and changelog records consistently

## Why

This records the maintainer decision to stop treating independent human security review as a release blocker while retaining the automated enterprise matrix and risk-accountability controls.

## Validation

- canonical Rust workspace gate
- repository policy suite (11/11)
- cargo-deny advisories, bans, licenses, and sources
- website typecheck
- website tests (25/25, 170 expectations)
- `git diff --check`