### PR TITLE
Recover staged release verification

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,16 +4,23 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing immutable tag whose draft release should be verified and published
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: stable-release-${{ github.ref }}
+  group: stable-release-${{ inputs.tag || github.ref }}
   cancel-in-progress: false
 
 env:
   CARGO_TERM_COLOR: always
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
   RUST_TOOLCHAIN: "1.97.1"
 
 jobs:
@@ -21,31 +28,45 @@ jobs:
     name: Validate immutable release identity
     runs-on: ubuntu-24.04
     outputs:
+      tag: ${{ steps.identity.outputs.tag }}
       version: ${{ steps.identity.outputs.version }}
     steps:
       - name: Check out the tagged commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Validate tag, versions, changelog, and commit
         id: identity
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
           version="$(tr -d '[:space:]' < VERSION)"
-          test "${GITHUB_REF_NAME}" = "v${version}"
-          test "$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}")" = tag
-          test "$(git rev-list -n 1 "${GITHUB_REF_NAME}")" = "${GITHUB_SHA}"
+          test "${RELEASE_TAG}" = "v${version}"
+          test "$(git cat-file -t "refs/tags/${RELEASE_TAG}")" = tag
+          test "$(git rev-list -n 1 "${RELEASE_TAG}")" = "$(git rev-parse HEAD)"
+          if test "${GITHUB_EVENT_NAME}" = push; then
+            test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          else
+            git fetch --no-tags origin "${GITHUB_REPOSITORY_DEFAULT_BRANCH}"
+            git merge-base --is-ancestor HEAD FETCH_HEAD
+            test "$(gh release view "${RELEASE_TAG}" --repo "${REPOSITORY}" --json isDraft --jq .isDraft)" = true
+          fi
           test "$(node -p "require('./package.json').version")" = "${version}"
           test "$(node -p "require('./website/package.json').version")" = "${version}"
           test "$(node -p "require('./website/tachyon.json').application.version")" = "${version}"
           grep -Eq "^## \[${version}\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md
           git diff --exit-code
+          echo "tag=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
   qualification:
     name: Complete enterprise qualification
+    if: github.event_name == 'push'
     uses: ./.github/workflows/rust-ci.yml
     permissions:
       contents: read
@@ -54,6 +75,7 @@ jobs:
 
   build:
     name: Native release artifact (${{ matrix.asset }})
+    if: github.event_name == 'push'
     needs: [validate, qualification]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
@@ -133,6 +155,7 @@ jobs:
 
   sbom:
     name: Release CycloneDX SBOM
+    if: github.event_name == 'push'
     needs: [validate, qualification]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -172,6 +195,7 @@ jobs:
 
   stage-release:
     name: Sign and stage immutable draft release
+    if: github.event_name == 'push'
     needs: [validate, build, sbom]
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -220,7 +244,7 @@ jobs:
       - name: Create a non-public draft from the existing tag
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
+          TAG: ${{ needs.validate.outputs.tag }}
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
@@ -236,6 +260,10 @@ jobs:
   verify-release:
     name: Verify staged release (${{ matrix.os }})
     needs: [validate, stage-release]
+    if: >-
+      always() &&
+      needs.validate.result == 'success' &&
+      (needs.stage-release.result == 'success' || github.event_name == 'workflow_dispatch')
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 25
     permissions:
@@ -275,11 +303,12 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ needs.validate.outputs.tag }}
         run: |
           set -euo pipefail
           mkdir release
-          gh release download "${TAG}" --dir release
+          gh release download "${TAG}" --repo "${REPOSITORY}" --dir release
 
       - name: Verify checksums, attestations, and signatures
         shell: bash
@@ -407,7 +436,7 @@ jobs:
 
   publish:
     name: Publish verified stable release
-    needs: [verify-release]
+    needs: [validate, verify-release]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -416,5 +445,6 @@ jobs:
       - name: Make the fully verified release public
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ github.ref_name }}
-        run: gh release edit "${TAG}" --draft=false --latest
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: gh release edit "${TAG}" --repo "${REPOSITORY}" --draft=false --latest

--- a/crates/tachyon-contracts/tests/repository_policy.rs
+++ b/crates/tachyon-contracts/tests/repository_policy.rs
@@ -307,14 +307,22 @@ fn stable_release_is_tag_gated_and_fail_closed() -> Result<(), Box<dyn std::erro
     let windows_installer = fs::read_to_string(root.join("install.ps1"))?;
 
     assert!(workflow.contains("tags:"));
+    assert!(workflow.contains("workflow_dispatch:"));
     assert!(!workflow.contains("branches: [main]"));
+    assert!(workflow.contains("RELEASE_TAG: ${{ inputs.tag || github.ref_name }}"));
     assert!(workflow.contains("git cat-file -t"));
     assert!(workflow.contains("uses: ./.github/workflows/rust-ci.yml"));
     assert!(workflow.contains("--verify-tag --draft"));
     assert!(workflow.contains("gh attestation verify"));
     assert!(workflow.contains("cosign verify-blob"));
     assert!(workflow.contains("sha256sum --check --strict SHA256SUMS"));
-    assert!(workflow.contains("gh release edit \"${TAG}\" --draft=false --latest"));
+    assert!(
+        workflow.contains("gh release download \"${TAG}\" --repo \"${REPOSITORY}\" --dir release")
+    );
+    assert!(
+        workflow
+            .contains("gh release edit \"${TAG}\" --repo \"${REPOSITORY}\" --draft=false --latest")
+    );
     assert!(workflow.contains("failed upgrade replaced the installed executable"));
 
     assert!(unix_installer.contains("No checksum published for ${asset}. Aborting."));


### PR DESCRIPTION
## What changed

- passes the repository explicitly to `gh release download` and `gh release edit` in checkout-free jobs
- adds a guarded `workflow_dispatch` recovery path for an existing immutable draft release
- requires recovery tags to be annotated, version-consistent, on main history, and attached to a draft
- extends repository policy coverage for the recovery controls

## Root cause

Run 31330258886 successfully qualified, built, signed, attested, and staged all release assets. Every verifier then failed before download because GitHub CLI attempted repository inference outside a checkout.

## Recovery

After this PR merges, dispatch `publish.yml` on `main` with `tag=v26.31.06`. Build and staging jobs remain skipped; the five native verification jobs download the existing immutable draft, verify checksums/attestations/signatures/installers, and only then publish it. The tag is never moved.

## Validation

- complete canonical Rust gate
- repository policy tests (11/11)
- actionlint (existing ShellCheck advisories excluded)
- `git diff --check`
- incremental Graphify refresh