### PR TITLE
Use the workflow default branch context

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ jobs:
         id: identity
         shell: bash
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
         run: |
@@ -52,7 +53,7 @@ jobs:
           if test "${GITHUB_EVENT_NAME}" = push; then
             test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
           else
-            git fetch --no-tags origin "${GITHUB_REPOSITORY_DEFAULT_BRANCH}"
+            git fetch --no-tags origin "${DEFAULT_BRANCH}"
             git merge-base --is-ancestor HEAD FETCH_HEAD
             test "$(gh release view "${RELEASE_TAG}" --repo "${REPOSITORY}" --json isDraft --jq .isDraft)" = true
           fi

--- a/crates/tachyon-contracts/tests/repository_policy.rs
+++ b/crates/tachyon-contracts/tests/repository_policy.rs
@@ -310,6 +310,7 @@ fn stable_release_is_tag_gated_and_fail_closed() -> Result<(), Box<dyn std::erro
     assert!(workflow.contains("workflow_dispatch:"));
     assert!(!workflow.contains("branches: [main]"));
     assert!(workflow.contains("RELEASE_TAG: ${{ inputs.tag || github.ref_name }}"));
+    assert!(workflow.contains("DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}"));
     assert!(workflow.contains("git cat-file -t"));
     assert!(workflow.contains("uses: ./.github/workflows/rust-ci.yml"));
     assert!(workflow.contains("--verify-tag --draft"));


### PR DESCRIPTION
## What changed

- exposes the repository default branch from the supported GitHub event context
- uses that value for the recovery tag ancestry check
- locks the supported expression into repository policy coverage

## Root cause

The first recovery dispatch stopped before verification because `GITHUB_REPOSITORY_DEFAULT_BRANCH` is not a GitHub Actions default environment variable.

## Validation

- complete canonical Rust gate
- actionlint (existing ShellCheck advisories excluded)
- repository policy tests (11/11)
- `git diff --check`
- incremental Graphify refresh