### PR TITLE
Allow staged release draft access

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,8 @@ jobs:
   validate:
     name: Validate immutable release identity
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     outputs:
       tag: ${{ steps.identity.outputs.tag }}
       version: ${{ steps.identity.outputs.version }}
@@ -268,7 +270,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 25
     permissions:
-      contents: read
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/crates/tachyon-contracts/tests/repository_policy.rs
+++ b/crates/tachyon-contracts/tests/repository_policy.rs
@@ -311,6 +311,7 @@ fn stable_release_is_tag_gated_and_fail_closed() -> Result<(), Box<dyn std::erro
     assert!(!workflow.contains("branches: [main]"));
     assert!(workflow.contains("RELEASE_TAG: ${{ inputs.tag || github.ref_name }}"));
     assert!(workflow.contains("DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}"));
+    assert!(workflow.matches("contents: write").count() >= 4);
     assert!(workflow.contains("git cat-file -t"));
     assert!(workflow.contains("uses: ./.github/workflows/rust-ci.yml"));
     assert!(workflow.contains("--verify-tag --draft"));


### PR DESCRIPTION
## Summary
- grant the release identity validator access to inspect the private staged draft
- grant platform verifiers access to download assets from that draft
- enforce the four narrowly-scoped contents-write jobs in repository policy

## Root cause
The recovery workflow read-only token received a release-not-found response for the private draft. GitHub draft releases require write-level contents access for discovery and download. Public promotion remains isolated in the separately gated publish job.

## Validation
- cargo fmt --check
- cargo check --workspace --all-targets --all-features --locked
- cargo clippy --workspace --all-targets --all-features --locked -- -D warnings
- cargo test --workspace --all-targets --all-features --locked
- RUSTDOCFLAGS=-D-warnings cargo doc --workspace --all-features --no-deps --locked
- cargo deny check advisories bans licenses sources
- actionlint
- Graphify incremental AST refresh