### PR TITLE
Make Windows release verification atomic

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -419,16 +419,21 @@ jobs:
             $installed = Join-Path $env:TACHYON_INSTALL_DIR 'ty.exe'
             [IO.File]::WriteAllText($installed, 'known-good')
             $knownGood = (Get-FileHash -Algorithm SHA256 $installed).Hash
-            $publishedSums = Get-Content 'release/SHA256SUMS' -Raw
+            $sumsPath = (Resolve-Path 'release/SHA256SUMS').Path
+            $validSumsPath = Join-Path $env:RUNNER_TEMP 'SHA256SUMS.valid'
+            $badSumsPath = Join-Path $env:RUNNER_TEMP 'SHA256SUMS.bad'
+            [IO.File]::Copy($sumsPath, $validSumsPath, $true)
+            $publishedSums = [IO.File]::ReadAllText($sumsPath)
             try {
               $badSums = $publishedSums -replace "(?m)^[0-9a-fA-F]{64}(\s+$([regex]::Escape($env:ASSET)))$", (('0' * 64) + '$1')
-              Set-Content -Path 'release/SHA256SUMS' -Value $badSums -NoNewline
+              [IO.File]::WriteAllText($badSumsPath, $badSums)
+              [IO.File]::Replace($badSumsPath, $sumsPath, $null)
               & ./release/install.ps1
               throw 'installer accepted a mismatched checksum'
             } catch {
               if ($_.Exception.Message -eq 'installer accepted a mismatched checksum') { throw }
             } finally {
-              Set-Content -Path 'release/SHA256SUMS' -Value $publishedSums -NoNewline
+              [IO.File]::Replace($validSumsPath, $sumsPath, $null)
             }
             if ((Get-FileHash -Algorithm SHA256 $installed).Hash -ne $knownGood) { throw 'failed upgrade replaced the installed executable' }
             & ./release/install.ps1

--- a/crates/tachyon-contracts/tests/repository_policy.rs
+++ b/crates/tachyon-contracts/tests/repository_policy.rs
@@ -318,6 +318,7 @@ fn stable_release_is_tag_gated_and_fail_closed() -> Result<(), Box<dyn std::erro
     assert!(workflow.contains("gh attestation verify"));
     assert!(workflow.contains("cosign verify-blob"));
     assert!(workflow.contains("sha256sum --check --strict SHA256SUMS"));
+    assert_eq!(workflow.matches("[IO.File]::Replace").count(), 2);
     assert!(
         workflow.contains("gh release download \"${TAG}\" --repo \"${REPOSITORY}\" --dir release")
     );


### PR DESCRIPTION
## Summary
- preserve the published checksum file in a separate temporary path
- atomically swap the corrupted negative-test file into service
- atomically restore the valid checksum file before the successful installer test
- enforce the two atomic replacements in repository policy

## Root cause
The Windows verifier used Set-Content against a file concurrently served by the local HTTP server. During restoration the server could observe the file after truncation but before the valid bytes were written, causing a false missing-checksum failure. The release assets themselves passed checksum, attestation, signature, and raw-executable verification; Linux and macOS installs passed.

## Validation
- full canonical Rust gate
- cargo deny advisories bans licenses sources
- actionlint
- Graphify incremental AST refresh