### PR TITLE
Provide Windows replacement backup paths

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -422,18 +422,17 @@ jobs:
             $sumsPath = (Resolve-Path 'release/SHA256SUMS').Path
             $validSumsPath = Join-Path $env:RUNNER_TEMP 'SHA256SUMS.valid'
             $badSumsPath = Join-Path $env:RUNNER_TEMP 'SHA256SUMS.bad'
-            [IO.File]::Copy($sumsPath, $validSumsPath, $true)
             $publishedSums = [IO.File]::ReadAllText($sumsPath)
             try {
               $badSums = $publishedSums -replace "(?m)^[0-9a-fA-F]{64}(\s+$([regex]::Escape($env:ASSET)))$", (('0' * 64) + '$1')
               [IO.File]::WriteAllText($badSumsPath, $badSums)
-              [IO.File]::Replace($badSumsPath, $sumsPath, $null)
+              [IO.File]::Replace($badSumsPath, $sumsPath, $validSumsPath)
               & ./release/install.ps1
               throw 'installer accepted a mismatched checksum'
             } catch {
               if ($_.Exception.Message -eq 'installer accepted a mismatched checksum') { throw }
             } finally {
-              [IO.File]::Replace($validSumsPath, $sumsPath, $null)
+              [IO.File]::Replace($validSumsPath, $sumsPath, $badSumsPath)
             }
             if ((Get-FileHash -Algorithm SHA256 $installed).Hash -ne $knownGood) { throw 'failed upgrade replaced the installed executable' }
             & ./release/install.ps1


### PR DESCRIPTION
## Summary
- let the first atomic checksum replacement create the valid backup
- atomically restore that backup while preserving the corrupted file
- remove the unsupported null backup arguments on Windows

## Root cause
The Windows runner requires a real backup path for File.Replace. Passing null failed before the checksum drill could run and was initially hidden by the drill catch block; restoration surfaced the same API error. This uses the documented three-path replacement flow in both directions.

## Validation
- full canonical Rust gate
- cargo deny advisories bans licenses sources
- actionlint
- Graphify checked: no supported code or document inputs changed