### PR TITLE
Isolate Windows release verification fixtures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -402,39 +402,38 @@ jobs:
           ASSET: ${{ matrix.asset }}
         run: |
           if ((& "release/$env:ASSET" --version) -ne $env:VERSION) { throw 'raw executable version mismatch' }
-          $server = Start-Process python -ArgumentList '-m','http.server','38191','--bind','127.0.0.1','--directory','release' -PassThru
+          New-Item -ItemType Directory -Force -Path 'release-bad' | Out-Null
+          Copy-Item "release/$env:ASSET" "release-bad/$env:ASSET"
+          $publishedSums = [IO.File]::ReadAllText((Resolve-Path 'release/SHA256SUMS').Path)
+          $badSums = $publishedSums -replace "(?m)^[0-9a-fA-F]{64}([ \t]+$([regex]::Escape($env:ASSET))\r?)$", (('0' * 64) + '$1')
+          if ($badSums -eq $publishedSums) { throw 'failed to corrupt the Windows checksum fixture' }
+          [IO.File]::WriteAllText((Join-Path $PWD 'release-bad/SHA256SUMS'), $badSums)
+          $server = Start-Process python -ArgumentList '-m','http.server','38191','--bind','127.0.0.1','--directory','.' -PassThru
           try {
             foreach ($attempt in 1..5) {
               try {
-                Invoke-WebRequest -Uri 'http://127.0.0.1:38191/SHA256SUMS' -UseBasicParsing | Out-Null
+                Invoke-WebRequest -Uri 'http://127.0.0.1:38191/release/SHA256SUMS' -UseBasicParsing | Out-Null
                 break
               } catch {
                 if ($attempt -eq 5) { throw }
                 Start-Sleep -Seconds 1
               }
             }
-            $env:TACHYON_BASE_URL = 'http://127.0.0.1:38191'
             $env:TACHYON_INSTALL_DIR = Join-Path $env:RUNNER_TEMP 'tachyon-bin'
             New-Item -ItemType Directory -Force -Path $env:TACHYON_INSTALL_DIR | Out-Null
             $installed = Join-Path $env:TACHYON_INSTALL_DIR 'ty.exe'
             [IO.File]::WriteAllText($installed, 'known-good')
             $knownGood = (Get-FileHash -Algorithm SHA256 $installed).Hash
-            $sumsPath = (Resolve-Path 'release/SHA256SUMS').Path
-            $validSumsPath = Join-Path $env:RUNNER_TEMP 'SHA256SUMS.valid'
-            $badSumsPath = Join-Path $env:RUNNER_TEMP 'SHA256SUMS.bad'
-            $publishedSums = [IO.File]::ReadAllText($sumsPath)
+            $env:TACHYON_BASE_URL = 'http://127.0.0.1:38191/release-bad'
             try {
-              $badSums = $publishedSums -replace "(?m)^[0-9a-fA-F]{64}(\s+$([regex]::Escape($env:ASSET)))$", (('0' * 64) + '$1')
-              [IO.File]::WriteAllText($badSumsPath, $badSums)
-              [IO.File]::Replace($badSumsPath, $sumsPath, $validSumsPath)
               & ./release/install.ps1
               throw 'installer accepted a mismatched checksum'
             } catch {
               if ($_.Exception.Message -eq 'installer accepted a mismatched checksum') { throw }
-            } finally {
-              [IO.File]::Replace($validSumsPath, $sumsPath, $badSumsPath)
+              if ($_.Exception.Message -ne "Checksum mismatch for $env:ASSET. Aborting.") { throw }
             }
             if ((Get-FileHash -Algorithm SHA256 $installed).Hash -ne $knownGood) { throw 'failed upgrade replaced the installed executable' }
+            $env:TACHYON_BASE_URL = 'http://127.0.0.1:38191/release'
             & ./release/install.ps1
             if ((& "$env:TACHYON_INSTALL_DIR/ty.exe" --version) -ne $env:VERSION) { throw 'installed executable version mismatch' }
           } finally {

--- a/crates/tachyon-contracts/tests/repository_policy.rs
+++ b/crates/tachyon-contracts/tests/repository_policy.rs
@@ -318,7 +318,8 @@ fn stable_release_is_tag_gated_and_fail_closed() -> Result<(), Box<dyn std::erro
     assert!(workflow.contains("gh attestation verify"));
     assert!(workflow.contains("cosign verify-blob"));
     assert!(workflow.contains("sha256sum --check --strict SHA256SUMS"));
-    assert_eq!(workflow.matches("[IO.File]::Replace").count(), 2);
+    assert!(workflow.contains("release-bad"));
+    assert!(workflow.contains("Checksum mismatch for $env:ASSET. Aborting."));
     assert!(
         workflow.contains("gh release download \"${TAG}\" --repo \"${REPOSITORY}\" --dir release")
     );


### PR DESCRIPTION
## Summary
- serve corrupted and valid checksum fixtures from distinct URLs
- keep the published release directory untouched during the negative drill
- require the negative installer run to fail with the exact checksum-mismatch error
- retain the installed-binary atomicity assertion before the successful clean install

## Root cause
Windows web caching reused the deliberately corrupted SHA256SUMS response after the valid file was restored at the same URL. The broad catch also accepted any installer failure, masking earlier verifier setup errors. Separate fixture URLs eliminate cache ambiguity, and exact error matching makes the drill fail closed.

## Validation
- full canonical Rust gate
- cargo deny advisories bans licenses sources
- actionlint
- Graphify incremental AST refresh