### PR TITLE
Generate a canonical bad checksum fixture

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -404,9 +404,7 @@ jobs:
           if ((& "release/$env:ASSET" --version) -ne $env:VERSION) { throw 'raw executable version mismatch' }
           New-Item -ItemType Directory -Force -Path 'release-bad' | Out-Null
           Copy-Item "release/$env:ASSET" "release-bad/$env:ASSET"
-          $publishedSums = [IO.File]::ReadAllText((Resolve-Path 'release/SHA256SUMS').Path)
-          $badSums = $publishedSums -replace "(?m)^[0-9a-fA-F]{64}([ \t]+$([regex]::Escape($env:ASSET))\r?)$", (('0' * 64) + '$1')
-          if ($badSums -eq $publishedSums) { throw 'failed to corrupt the Windows checksum fixture' }
+          $badSums = ('0' * 64) + "  $env:ASSET`n"
           [IO.File]::WriteAllText((Join-Path $PWD 'release-bad/SHA256SUMS'), $badSums)
           $server = Start-Process python -ArgumentList '-m','http.server','38191','--bind','127.0.0.1','--directory','.' -PassThru
           try {

--- a/crates/tachyon-contracts/tests/repository_policy.rs
+++ b/crates/tachyon-contracts/tests/repository_policy.rs
@@ -319,6 +319,7 @@ fn stable_release_is_tag_gated_and_fail_closed() -> Result<(), Box<dyn std::erro
     assert!(workflow.contains("cosign verify-blob"));
     assert!(workflow.contains("sha256sum --check --strict SHA256SUMS"));
     assert!(workflow.contains("release-bad"));
+    assert!(workflow.contains("$badSums = ('0' * 64) + \"  $env:ASSET`n\""));
     assert!(workflow.contains("Checksum mismatch for $env:ASSET. Aborting."));
     assert!(
         workflow.contains("gh release download \"${TAG}\" --repo \"${REPOSITORY}\" --dir release")


### PR DESCRIPTION
## Summary
- generate the negative Windows SHA256SUMS fixture directly in canonical sha256sum format
- retain distinct negative and positive URLs
- enforce the exact fixture grammar in repository policy

## Root cause
The regex-transformed negative fixture did not match the installer checksum-entry grammar, so the precise fail-closed assertion correctly reported a missing entry instead of a digest mismatch. A single deterministic line with 64 zeros, two spaces, and the exact asset name removes that ambiguity.

## Validation
- full canonical Rust gate
- cargo deny advisories bans licenses sources
- actionlint
- Graphify incremental AST refresh