### PR TITLE
Build the Windows checksum as a string

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -404,7 +404,7 @@ jobs:
           if ((& "release/$env:ASSET" --version) -ne $env:VERSION) { throw 'raw executable version mismatch' }
           New-Item -ItemType Directory -Force -Path 'release-bad' | Out-Null
           Copy-Item "release/$env:ASSET" "release-bad/$env:ASSET"
-          $badSums = ('0' * 64) + "  $env:ASSET`n"
+          $badSums = [string]::new('0', 64) + "  $env:ASSET`n"
           [IO.File]::WriteAllText((Join-Path $PWD 'release-bad/SHA256SUMS'), $badSums)
           $server = Start-Process python -ArgumentList '-m','http.server','38191','--bind','127.0.0.1','--directory','.' -PassThru
           try {

--- a/crates/tachyon-contracts/tests/repository_policy.rs
+++ b/crates/tachyon-contracts/tests/repository_policy.rs
@@ -319,7 +319,7 @@ fn stable_release_is_tag_gated_and_fail_closed() -> Result<(), Box<dyn std::erro
     assert!(workflow.contains("cosign verify-blob"));
     assert!(workflow.contains("sha256sum --check --strict SHA256SUMS"));
     assert!(workflow.contains("release-bad"));
-    assert!(workflow.contains("$badSums = ('0' * 64) + \"  $env:ASSET`n\""));
+    assert!(workflow.contains("$badSums = [string]::new('0', 64) + \"  $env:ASSET`n\""));
     assert!(workflow.contains("Checksum mismatch for $env:ASSET. Aborting."));
     assert!(
         workflow.contains("gh release download \"${TAG}\" --repo \"${REPOSITORY}\" --dir release")


### PR DESCRIPTION
## Summary
- construct the negative checksum with String.new so PowerShell produces one 64-character scalar
- keep the exact canonical checksum grammar assertion in repository policy

## Root cause
In PowerShell, multiplying a string by 64 produces an array rather than a concatenated string. Passing that array to WriteAllText created a malformed checksum fixture. String.new creates the intended 64-character digest deterministically.

## Validation
- full canonical Rust gate
- cargo deny advisories bans licenses sources
- actionlint
- Graphify incremental AST refresh