### PR TITLE
test(release): corrupt Windows fixture payload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -404,8 +404,8 @@ jobs:
           if ((& "release/$env:ASSET" --version) -ne $env:VERSION) { throw 'raw executable version mismatch' }
           New-Item -ItemType Directory -Force -Path 'release-bad' | Out-Null
           Copy-Item "release/$env:ASSET" "release-bad/$env:ASSET"
-          $badSums = [string]::new('0', 64) + "  $env:ASSET`n"
-          [IO.File]::WriteAllText((Join-Path $PWD 'release-bad/SHA256SUMS'), $badSums)
+          Copy-Item 'release/SHA256SUMS' 'release-bad/SHA256SUMS'
+          [IO.File]::AppendAllText((Join-Path $PWD "release-bad/$env:ASSET"), 'corrupt')
           $server = Start-Process python -ArgumentList '-m','http.server','38191','--bind','127.0.0.1','--directory','.' -PassThru
           try {
             foreach ($attempt in 1..5) {

--- a/crates/tachyon-contracts/tests/repository_policy.rs
+++ b/crates/tachyon-contracts/tests/repository_policy.rs
@@ -319,7 +319,8 @@ fn stable_release_is_tag_gated_and_fail_closed() -> Result<(), Box<dyn std::erro
     assert!(workflow.contains("cosign verify-blob"));
     assert!(workflow.contains("sha256sum --check --strict SHA256SUMS"));
     assert!(workflow.contains("release-bad"));
-    assert!(workflow.contains("$badSums = [string]::new('0', 64) + \"  $env:ASSET`n\""));
+    assert!(workflow.contains("Copy-Item 'release/SHA256SUMS' 'release-bad/SHA256SUMS'"));
+    assert!(workflow.contains("[IO.File]::AppendAllText"));
     assert!(workflow.contains("Checksum mismatch for $env:ASSET. Aborting."));
     assert!(
         workflow.contains("gh release download \"${TAG}\" --repo \"${REPOSITORY}\" --dir release")


### PR DESCRIPTION
## Summary
- preserve the canonical staged SHA256SUMS manifest in the Windows negative installer fixture
- corrupt the copied executable instead of synthesizing a checksum line
- update the repository policy assertion to enforce the stronger fixture

## Validation
- actionlint -shellcheck= .github/workflows/publish.yml
- full canonical Rust gate (fmt, check, clippy, test, docs, cargo-deny)

## Release recovery
This is the smallest fix for the Windows verifier failure in Stable Release run 31340739417. After exact-head checks pass, merge and rerun the v26.31.06 recovery publication.