### PR TITLE
fix(release): publish verified recovery runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -441,6 +441,10 @@ jobs:
   publish:
     name: Publish verified stable release
     needs: [validate, verify-release]
+    if: >-
+      always() &&
+      needs.validate.result == 'success' &&
+      needs.verify-release.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/crates/tachyon-contracts/tests/repository_policy.rs
+++ b/crates/tachyon-contracts/tests/repository_policy.rs
@@ -331,6 +331,7 @@ fn stable_release_is_tag_gated_and_fail_closed() -> Result<(), Box<dyn std::erro
     );
     assert!(workflow.contains("failed upgrade replaced the installed executable"));
     assert!(!workflow.contains("environment: packages-prod"));
+    assert!(workflow.contains("needs.verify-release.result == 'success'"));
 
     assert!(unix_installer.contains("No checksum published for ${asset}. Aborting."));
     assert!(unix_installer.contains("mktemp \"${dest}/.ty.download.XXXXXX\""));


### PR DESCRIPTION
## Summary
- make the publish job run after an explicit successful identity check and successful five-platform verification matrix
- preserve fail-closed publication while allowing recovery workflows to publish an already-staged draft
- add repository-policy coverage for the explicit verifier dependency

## Root cause
The recovery workflow intentionally skips staging jobs, so GitHub's implicit `success()` condition caused the final publish job to be skipped even though both required recovery jobs passed.

## Validation
- `actionlint -shellcheck= .github/workflows/publish.yml`
- full canonical Rust gate
- `cargo deny check advisories bans licenses sources`

After merge, the existing fully verified `v26.33.01` draft will be recovered and published.